### PR TITLE
Use ELBSecurityPolicy-FS-1-2-Res-2020-10 for load balancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ resources that lack official modules.
 | <a name="input_network_private_subnets"></a> [network\_private\_subnets](#input\_network\_private\_subnets) | A list of public subnets inside the VPC. | `list(string)` | <pre>[<br>  "10.0.32.0/20",<br>  "10.0.48.0/20"<br>]</pre> | no |
 | <a name="input_network_public_subnets"></a> [network\_public\_subnets](#input\_network\_public\_subnets) | A list of private subnets inside the VPC. | `list(string)` | <pre>[<br>  "10.0.0.0/20",<br>  "10.0.16.0/20"<br>]</pre> | no |
 | <a name="input_public_access"></a> [public\_access](#input\_public\_access) | Is this instance accessable a public domain. | `bool` | `false` | no |
-| <a name="input_ssl_policy"></a> [ssl\_policy](#input\_ssl\_policy) | SSL policy to use on ALB listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| <a name="input_ssl_policy"></a> [ssl\_policy](#input\_ssl\_policy) | SSL policy to use on ALB listener | `string` | `"ELBSecurityPolicy-FS-1-2-Res-2020-10"` | no |
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain for accessing the Weights & Biases UI. Default creates record at Route53 Route. | `string` | `null` | no |
 | <a name="input_wandb_image"></a> [wandb\_image](#input\_wandb\_image) | Docker repository of to pull the wandb image from. | `string` | `"wandb/local"` | no |
 | <a name="input_wandb_license"></a> [wandb\_license](#input\_wandb\_license) | The license for deploying Weights & Biases local. | `string` | `null` | no |

--- a/modules/app_lb/variables.tf
+++ b/modules/app_lb/variables.tf
@@ -12,7 +12,7 @@ variable "acm_certificate_arn" {
 
 variable "ssl_policy" {
   type        = string
-  default     = "ELBSecurityPolicy-2016-08"
+  default     = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   description = "(Optional) SSL policy to use on ALB listener"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "subdomain" {
 ##########################################
 variable "ssl_policy" {
   type        = string
-  default     = "ELBSecurityPolicy-2016-08"
+  default     = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   description = "SSL policy to use on ALB listener"
 }
 


### PR DESCRIPTION
- Uses the more restrictive ELBSecurityPolicy-FS-1-2-Res-2020-10 to only support TLS 1.2 and not 1.1/1.0.

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#tls-security-policies