### PR TITLE
Do not allow any connections inbound by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,15 +138,15 @@ resources that lack official modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acm_certificate_arn"></a> [acm\_certificate\_arn](#input\_acm\_certificate\_arn) | The ARN of an existing ACM certificate. | `string` | `null` | no |
-| <a name="input_allowed_inbound_cidr"></a> [allowed\_inbound\_cidr](#input\_allowed\_inbound\_cidr) | Allow HTTP(S) traffic to W&B. Defaults to all connections. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| <a name="input_allowed_inbound_ipv6_cidr"></a> [allowed\_inbound\_ipv6\_cidr](#input\_allowed\_inbound\_ipv6\_cidr) | Allow HTTP(S) traffic to W&B. Defaults to all connections. | `list(string)` | <pre>[<br>  "::/0"<br>]</pre> | no |
+| <a name="input_allowed_inbound_cidr"></a> [allowed\_inbound\_cidr](#input\_allowed\_inbound\_cidr) | Allow HTTP(S) traffic to W&B. Defaults to no connections. | `list(string)` | <pre>[]</pre> | no |
+| <a name="input_allowed_inbound_ipv6_cidr"></a> [allowed\_inbound\_ipv6\_cidr](#input\_allowed\_inbound\_ipv6\_cidr) | Allow HTTP(S) traffic to W&B. Defaults to no connections. | `list(string)` | <pre>[]</pre> | no |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Boolean indicating whether to deploy a VPC (true) or not (false). | `bool` | `true` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain for accessing the Weights & Biases UI. | `string` | n/a | yes |
 | <a name="input_external_dns"></a> [external\_dns](#input\_external\_dns) | Using external DNS. A `subdomain` must also be specified if this value is true. | `bool` | `false` | no |
 | <a name="input_kms_key_alias"></a> [kms\_key\_alias](#input\_kms\_key\_alias) | KMS key alias for AWS KMS Customer managed key. | `string` | `"wandb-managed-kms"` | no |
 | <a name="input_kms_key_deletion_window"></a> [kms\_key\_deletion\_window](#input\_kms\_key\_deletion\_window) | Duration in days to destroy the key after it is deleted. Must be between 7 and 30 days. | `number` | `7` | no |
 | <a name="input_kubernetes_public_access"></a> [kubernetes\_public\_access](#input\_kubernetes\_public\_access) | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | `bool` | `true` | no |
-| <a name="input_kubernetes_public_access_cidrs"></a> [kubernetes\_public\_access\_cidrs](#input\_kubernetes\_public\_access\_cidrs) | List of CIDR blocks which can access the Amazon EKS public API server endpoint. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_kubernetes_public_access_cidrs"></a> [kubernetes\_public\_access\_cidrs](#input\_kubernetes\_public\_access\_cidrs) | List of CIDR blocks which can access the Amazon EKS public API server endpoint. | `list(string)` | <pre>[]</pre> | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | String used for prefix resources. | `string` | n/a | yes |
 | <a name="input_network_cidr"></a> [network\_cidr](#input\_network\_cidr) | CIDR block for VPC. | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The identity of the VPC in which resources will be deployed. | `string` | `""` | no |

--- a/modules/app_lb/variables.tf
+++ b/modules/app_lb/variables.tf
@@ -39,14 +39,14 @@ variable "load_balancing_scheme" {
 
 variable "allowed_inbound_cidr" {
   type        = list(string)
-  default     = ["0.0.0.0/0"]
-  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  default     = []
+  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to no connections."
 }
 
 variable "allowed_inbound_ipv6_cidr" {
   type        = list(string)
-  default     = ["::/0"]
-  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  default     = []
+  description = "(Optional) Allow HTTP(S) traffic to W&B. Defaults to no connections."
 }
 
 variable "network_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -58,14 +58,14 @@ variable "acm_certificate_arn" {
 
 variable "allowed_inbound_cidr" {
   type        = list(string)
-  default     = ["0.0.0.0/0"]
-  description = "Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  default     = []
+  description = "Allow HTTP(S) traffic to W&B. Defaults to no connections."
 }
 
 variable "allowed_inbound_ipv6_cidr" {
   type        = list(string)
-  default     = ["::/0"]
-  description = "Allow HTTP(S) traffic to W&B. Defaults to all connections."
+  default     = []
+  description = "Allow HTTP(S) traffic to W&B. Defaults to no connections."
 }
 
 
@@ -131,5 +131,5 @@ variable "kubernetes_public_access" {
 variable "kubernetes_public_access_cidrs" {
   description = "List of CIDR blocks which can access the Amazon EKS public API server endpoint."
   type        = list(string)
-  default     = ["0.0.0.0/0"]
+  default     = []
 }


### PR DESCRIPTION
We do not want to inadvertently increase attack surface, especially for self-managed deployments. This PR defaults inbound CIDR blocks to `[]` for both the load balancer and the EKS API. What might be a better UX is to not have a default and ensure the user enters their own CIDR block. 