### PR TITLE
[WB-7810] Add Redis Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@
 kubeconfig*
 cat.*
 test.py
+.idea
 
 **/wandb/*

--- a/examples/byob/main.tf
+++ b/examples/byob/main.tf
@@ -59,7 +59,7 @@ module "resources" {
   sse_algorithm = "aws:kms"
   kms_key_arn   = aws_kms_key.key.arn
 
-  # Use internal queue
+  # Use redis queue
   create_queue = false
 
   deletion_protection = false

--- a/examples/public-dns-with-route53/variables.tf
+++ b/examples/public-dns-with-route53/variables.tf
@@ -15,6 +15,6 @@ variable "subdomain" {
   description = "Subdomain for accessing the Weights & Biases UI."
 }
 
-variable "license" {
+variable "wandb_license" {
   type = string
 }

--- a/main.tf
+++ b/main.tf
@@ -168,4 +168,6 @@ module "redis" {
   vpc_id                  = local.network_id
   redis_subnet_group_name = local.network_elasticache_subnet_group_name
   vpc_subnets_cidr_blocks = module.networking.elasticache_subnet_cidrs
+
+  kms_key_arn = local.kms_key_arn
 }

--- a/main.tf
+++ b/main.tf
@@ -167,4 +167,5 @@ module "redis" {
 
   vpc_id                  = local.network_id
   redis_subnet_group_name = local.network_elasticache_subnet_group_name
+  vpc_subnets_cidr_blocks = module.networking.elasticache_subnet_cidrs
 }

--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -1,5 +1,6 @@
 locals {
   mysql_port = 3306
+  redis_port = 6379
 }
 
 data "aws_iam_policy_document" "node" {
@@ -153,3 +154,15 @@ resource "aws_security_group_rule" "database" {
   to_port                  = local.mysql_port
   type                     = "ingress"
 }
+
+resource "aws_security_group_rule" "elasticache" {
+  count                    = var.create_elasticache_security_group ? 1 : 0
+  description              = "Allow inbound traffic from EKS workers to elasticache"
+  protocol                 = "tcp"
+  security_group_id        = var.elasticache_security_group_id
+  source_security_group_id = module.eks.cluster_primary_security_group_id
+  from_port                = local.redis_port
+  to_port                  = local.redis_port
+  type                     = "ingress"
+}
+

--- a/modules/app_eks/variables.tf
+++ b/modules/app_eks/variables.tf
@@ -47,6 +47,16 @@ variable "database_security_group_id" {
   type = string
 }
 
+variable "elasticache_security_group_id" {
+  type = string
+  default = null
+}
+
+variable "create_elasticache_security_group" {
+  type = bool
+  default = false
+}
+
 variable "service_port" {
   type    = number
   default = 32543

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -13,11 +13,12 @@ module "vpc" {
   enable_dns_hostnames = true
   enable_dns_support   = true
 
-  azs              = data.aws_availability_zones.available.names
-  cidr             = var.cidr
-  private_subnets  = var.private_subnet_cidrs
-  public_subnets   = var.public_subnet_cidrs
-  database_subnets = var.database_subnet_cidrs
+  azs                 = data.aws_availability_zones.available.names
+  cidr                = var.cidr
+  private_subnets     = var.private_subnet_cidrs
+  public_subnets      = var.public_subnet_cidrs
+  database_subnets    = var.database_subnet_cidrs
+  elasticache_subnets = var.elasticache_subnet_cidrs
 
   enable_nat_gateway = true
   single_nat_gateway = false

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -53,6 +53,11 @@ output "elasticache_subnet_group_name" {
   description = "Name of elasticache subnet group."
 }
 
+output "elasticache_subnet_cidrs" {
+  value       = module.vpc.elasticache_subnets_cidr_blocks
+  description = "A list of the CIDR blocks which comprise the elasticache subnetworks."
+}
+
 output "private_route_table_ids" {
   value       = module.vpc.private_route_table_ids
   description = "List of IDs of private route tables"

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -48,6 +48,11 @@ output "database_subnet_group_name" {
   description = "Name of database subnet group."
 }
 
+output "elasticache_subnet_group_name" {
+  value       = module.vpc.elasticache_subnet_group_name
+  description = "Name of elasticache subnet group."
+}
+
 output "private_route_table_ids" {
   value       = module.vpc.private_route_table_ids
   description = "List of IDs of private route tables"

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -33,6 +33,12 @@ variable "database_subnet_cidrs" {
   default     = ["10.10.20.0/24", "10.10.21.0/24"]
 }
 
+variable "elasticache_subnet_cidrs" {
+  type        = list(string)
+  description = "(Optional) List of redis subnet CIDR ranges to create in VPC."
+  default     = ["10.10.30.0/24", "10.10.31.0/24"]
+}
+
 variable "enable_vpn_gateway" {
   type        = bool
   description = "(Optional) Should be true if you want to create a new VPN Gateway resource and attach it to the VPC."

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,0 +1,16 @@
+locals {
+  redis_version = "4.0.10"
+}
+
+resource "aws_elasticache_replication_group" "default" {
+  replication_group_id          = "${var.namespace}-rep-group"
+  replication_group_description = "${var.namespace}-rep-group"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis4.0"
+  automatic_failover_enabled    = true
+  multi_az_enabled              = true
+  port                          = 6379
+  maintenance_window            = var.preferred_maintenance_window
+  engine_version                = local.redis_version
+}

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -27,16 +27,14 @@ resource "aws_security_group" "redis" {
   ingress {
     protocol         = "tcp"
     from_port        = "6379"
-    to_port          =  "6379"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    to_port          = "6379"
+    cidr_blocks      = var.vpc_subnets_cidr_blocks
   }
 
   egress {
     protocol         = "-1"
     from_port        = 0
     to_port          = 0
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    cidr_blocks      = var.vpc_subnets_cidr_blocks
   }
 }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -18,6 +18,10 @@ resource "aws_elasticache_replication_group" "default" {
 
   subnet_group_name             = var.redis_subnet_group_name
   security_group_ids            = [aws_security_group.redis.id]
+
+  kms_key_id                 = var.kms_key_arn
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
 }
 
 resource "aws_security_group" "redis" {
@@ -32,9 +36,9 @@ resource "aws_security_group" "redis" {
   }
 
   egress {
-    protocol         = "-1"
-    from_port        = 0
-    to_port          = 0
+    protocol         = "tcp"
+    from_port        = "6379"
+    to_port          = "6379"
     cidr_blocks      = var.vpc_subnets_cidr_blocks
   }
 }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,16 +1,42 @@
 locals {
-  redis_version = "4.0.10"
+  redis_version = "6.x"
 }
 
 resource "aws_elasticache_replication_group" "default" {
   replication_group_id          = "${var.namespace}-rep-group"
   replication_group_description = "${var.namespace}-rep-group"
-  node_type                     = "cache.m4.large"
   number_cache_clusters         = 2
-  parameter_group_name          = "default.redis4.0"
+  port                          = 6379
+
+  node_type                     = "cache.t2.medium"
+  parameter_group_name          = "default.redis6.x"
+  engine_version                = local.redis_version
+
   automatic_failover_enabled    = true
   multi_az_enabled              = true
-  port                          = 6379
   maintenance_window            = var.preferred_maintenance_window
-  engine_version                = local.redis_version
+
+  subnet_group_name             = var.redis_subnet_group_name
+  security_group_ids            = [aws_security_group.redis.id]
+}
+
+resource "aws_security_group" "redis" {
+  name   = "${var.namespace}-elasticache-security-group"
+  vpc_id = var.vpc_id
+
+  ingress {
+    protocol         = "tcp"
+    from_port        = "6379"
+    to_port          =  "6379"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    protocol         = "-1"
+    from_port        = 0
+    to_port          = 0
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
 }

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,0 +1,3 @@
+output "connection_string" {
+  value = "${aws_elasticache_replication_group.default.primary_endpoint_address}:${aws_elasticache_replication_group.default.port}"
+}

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,3 +1,7 @@
 output "connection_string" {
   value = "${aws_elasticache_replication_group.default.primary_endpoint_address}:${aws_elasticache_replication_group.default.port}"
 }
+
+output "security_group_id" {
+  value = aws_security_group.redis.id
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -1,0 +1,10 @@
+variable "namespace" {
+  type        = string
+  description = "(Required) The name prefix for all resources created."
+}
+
+variable "preferred_maintenance_window" {
+  description = "(Optional) The weekly time range during which system maintenance can occur, in (UTC)"
+  type        = string
+  default     = "sun:03:00-sun:04:00"
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -25,3 +25,8 @@ variable "vpc_subnets_cidr_blocks" {
   type = list(string)
   default = []
 }
+
+variable "kms_key_arn" {
+  description = "The ARN for the KMS encryption key."
+  type        = string
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -8,3 +8,14 @@ variable "preferred_maintenance_window" {
   type        = string
   default     = "sun:03:00-sun:04:00"
 }
+
+variable "redis_subnet_group_name" {
+  description = "The name of the subnet group (existing)"
+  type        = string
+  default     = ""
+}
+
+variable "vpc_id" {
+  description = "The identity of the VPC in which the security group attached to elasticache will be deployed."
+  type        = string
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -19,3 +19,9 @@ variable "vpc_id" {
   description = "The identity of the VPC in which the security group attached to elasticache will be deployed."
   type        = string
 }
+
+variable "vpc_subnets_cidr_blocks" {
+  description = "A list of CIDR blocks which are allowed to access elasticache"
+  type = list(string)
+  default = []
+}

--- a/modules/redis/versions.tf
+++ b/modules/redis/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.60"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,3 +48,7 @@ output "url" {
 output "internal_app_port" {
   value = local.internal_app_port
 }
+
+output "elasticache_connection_string" {
+  value = var.use_internal_queue ? module.redis.0.connection_string : null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,5 +50,5 @@ output "internal_app_port" {
 }
 
 output "elasticache_connection_string" {
-  value = var.use_internal_queue ? module.redis.0.connection_string : null
+  value = var.create_elasticache ? module.redis.0.connection_string : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -155,6 +155,12 @@ variable "network_database_subnet_cidrs" {
   default     = ["10.10.20.0/24", "10.10.21.0/24"]
 }
 
+variable "network_elasticache_subnet_cidrs" {
+  type        = list(string)
+  description = "List of private subnet CIDR ranges to create in VPC."
+  default     = ["10.10.30.0/24", "10.10.31.0/24"]
+}
+
 
 ##########################################
 # EKS Cluster                            #
@@ -213,4 +219,13 @@ variable "bucket_kms_key_arn" {
   type        = string
   description = "The Amazon Resource Name of the KMS key with which S3 storage bucket objects will be encrypted."
   default     = ""
+}
+
+##########################################
+# Redis                                  #
+##########################################
+variable "create_elasticache" {
+  type        = bool
+  description = "Boolean indicating whether to provision an elasticache instance (true) or not (false)."
+  default     = false
 }


### PR DESCRIPTION
Jira 

https://wandb.atlassian.net/browse/WB-7810

Adds a redis module so that we can externalize the filemeta queue. There are some other prs here that are prerequisites to making this possible

1. [Allow using redis connection string for filemeta queue](https://github.com/wandb/core/pull/8623)
2. [Add redis var to wandb terraform](https://github.com/wandb/terraform-kubernetes-wandb/pull/1)

I've tested the redis module and tested that the output can be passed to wandb local. I still need to test deploying my local branch in AWS using the external redis instance for the filemeta queue to make sure there are no connection/network issues.