### PR TITLE
fix: Skip creating elasticache subnet if it is disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,10 +46,10 @@ module "networking" {
   namespace  = var.namespace
   create_vpc = var.create_vpc
 
-  cidr                  = var.network_cidr
-  private_subnet_cidrs  = var.network_private_subnet_cidrs
-  public_subnet_cidrs   = var.network_public_subnet_cidrs
-  database_subnet_cidrs = var.network_database_subnet_cidrs
+  cidr                      = var.network_cidr
+  private_subnet_cidrs      = var.network_private_subnet_cidrs
+  public_subnet_cidrs       = var.network_public_subnet_cidrs
+  database_subnet_cidrs     = var.network_database_subnet_cidrs
   create_elasticache_subnet = var.create_elasticache
   elasticache_subnet_cidrs  = var.network_elasticache_subnet_cidrs
 }
@@ -114,7 +114,7 @@ locals {
 module "app_eks" {
   source = "./modules/app_eks"
 
-  namespace   = var.namespace
+  namespace          = var.namespace
   bucket_kms_key_arn = local.provision_file_storage ? local.kms_key_arn : var.bucket_kms_key_arn
 
   map_accounts = var.kubernetes_map_accounts
@@ -127,8 +127,8 @@ module "app_eks" {
   network_id              = local.network_id
   network_private_subnets = local.network_private_subnets
 
-  lb_security_group_inbound_id  = module.app_lb.security_group_inbound_id
-  database_security_group_id    = module.database.security_group_id
+  lb_security_group_inbound_id = module.app_lb.security_group_inbound_id
+  database_security_group_id   = module.database.security_group_id
 
   create_elasticache_security_group = var.create_elasticache
   elasticache_security_group_id     = var.create_elasticache ? module.redis.0.security_group_id : null

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,8 @@ module "networking" {
   private_subnet_cidrs  = var.network_private_subnet_cidrs
   public_subnet_cidrs   = var.network_public_subnet_cidrs
   database_subnet_cidrs = var.network_database_subnet_cidrs
-  elasticache_subnet_cidrs = var.network_elasticache_subnet_cidrs
+  create_elasticache_subnet = var.create_elasticache
+  elasticache_subnet_cidrs  = var.network_elasticache_subnet_cidrs
 }
 
 locals {

--- a/modules/app_eks/variables.tf
+++ b/modules/app_eks/variables.tf
@@ -48,12 +48,12 @@ variable "database_security_group_id" {
 }
 
 variable "elasticache_security_group_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "create_elasticache_security_group" {
-  type = bool
+  type    = bool
   default = false
 }
 

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -18,7 +18,7 @@ module "vpc" {
   private_subnets     = var.private_subnet_cidrs
   public_subnets      = var.public_subnet_cidrs
   database_subnets    = var.database_subnet_cidrs
-  elasticache_subnets = var.elasticache_subnet_cidrs
+  elasticache_subnets = var.create_elasticache_subnet ? var.elasticache_subnet_cidrs : []
 
   enable_nat_gateway = true
   single_nat_gateway = false

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -39,6 +39,12 @@ variable "elasticache_subnet_cidrs" {
   default     = ["10.10.30.0/24", "10.10.31.0/24"]
 }
 
+variable "create_elasticache_subnet" {
+  type        = bool
+  description = "Boolean indicating whether to provision a subnet for elasticache."
+  default     = false
+}
+
 variable "enable_vpn_gateway" {
   type        = bool
   description = "(Optional) Should be true if you want to create a new VPN Gateway resource and attach it to the VPC."

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -8,16 +8,16 @@ resource "aws_elasticache_replication_group" "default" {
   number_cache_clusters         = 2
   port                          = 6379
 
-  node_type                     = "cache.t2.medium"
-  parameter_group_name          = "default.redis6.x"
-  engine_version                = local.redis_version
+  node_type            = "cache.t2.medium"
+  parameter_group_name = "default.redis6.x"
+  engine_version       = local.redis_version
 
-  automatic_failover_enabled    = true
-  multi_az_enabled              = true
-  maintenance_window            = var.preferred_maintenance_window
+  automatic_failover_enabled = true
+  multi_az_enabled           = true
+  maintenance_window         = var.preferred_maintenance_window
 
-  subnet_group_name             = var.redis_subnet_group_name
-  security_group_ids            = [aws_security_group.redis.id]
+  subnet_group_name  = var.redis_subnet_group_name
+  security_group_ids = [aws_security_group.redis.id]
 
   kms_key_id                 = var.kms_key_arn
   at_rest_encryption_enabled = true
@@ -29,16 +29,16 @@ resource "aws_security_group" "redis" {
   vpc_id = var.vpc_id
 
   ingress {
-    protocol         = "tcp"
-    from_port        = "6379"
-    to_port          = "6379"
-    cidr_blocks      = var.vpc_subnets_cidr_blocks
+    protocol    = "tcp"
+    from_port   = "6379"
+    to_port     = "6379"
+    cidr_blocks = var.vpc_subnets_cidr_blocks
   }
 
   egress {
-    protocol         = "tcp"
-    from_port        = "6379"
-    to_port          = "6379"
-    cidr_blocks      = var.vpc_subnets_cidr_blocks
+    protocol    = "tcp"
+    from_port   = "6379"
+    to_port     = "6379"
+    cidr_blocks = var.vpc_subnets_cidr_blocks
   }
 }

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -22,8 +22,8 @@ variable "vpc_id" {
 
 variable "vpc_subnets_cidr_blocks" {
   description = "A list of CIDR blocks which are allowed to access elasticache"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 
 variable "kms_key_arn" {


### PR DESCRIPTION
Skip creating the elasticache subnet if we aren't provisioning an elasticache instance