### PR TITLE
fix: Separate redis security group rules

### DIFF
--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -27,18 +27,22 @@ resource "aws_elasticache_replication_group" "default" {
 resource "aws_security_group" "redis" {
   name   = "${var.namespace}-elasticache-security-group"
   vpc_id = var.vpc_id
+}
 
-  ingress {
-    protocol    = "tcp"
-    from_port   = "6379"
-    to_port     = "6379"
-    cidr_blocks = var.vpc_subnets_cidr_blocks
-  }
+resource "aws_security_group_rule" "ingress" {
+  type        = "ingress"
+  protocol    = "tcp"
+  from_port   = "6379"
+  to_port     = "6379"
+  cidr_blocks = var.vpc_subnets_cidr_blocks
+  security_group_id = aws_security_group.redis.id
+}
 
-  egress {
-    protocol    = "tcp"
-    from_port   = "6379"
-    to_port     = "6379"
-    cidr_blocks = var.vpc_subnets_cidr_blocks
-  }
+resource "aws_security_group_rule" "egress" {
+  type        = "egress"
+  protocol    = "tcp"
+  from_port   = "6379"
+  to_port     = "6379"
+  cidr_blocks = var.vpc_subnets_cidr_blocks
+  security_group_id = aws_security_group.redis.id
 }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -30,19 +30,19 @@ resource "aws_security_group" "redis" {
 }
 
 resource "aws_security_group_rule" "ingress" {
-  type        = "ingress"
-  protocol    = "tcp"
-  from_port   = "6379"
-  to_port     = "6379"
-  cidr_blocks = var.vpc_subnets_cidr_blocks
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = "6379"
+  to_port           = "6379"
+  cidr_blocks       = var.vpc_subnets_cidr_blocks
   security_group_id = aws_security_group.redis.id
 }
 
 resource "aws_security_group_rule" "egress" {
-  type        = "egress"
-  protocol    = "tcp"
-  from_port   = "6379"
-  to_port     = "6379"
-  cidr_blocks = var.vpc_subnets_cidr_blocks
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = "6379"
+  to_port           = "6379"
+  cidr_blocks       = var.vpc_subnets_cidr_blocks
   security_group_id = aws_security_group.redis.id
 }


### PR DESCRIPTION
[Using inline security group rules in the `aws_security_group` resource along with the standalone `aws_security_group_rule` resource causes conflicts when the terraform is applied and rules to be overwritten](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group). This pr separates the rules out into their own resources.