### PR TITLE
fix: Reference file storage module in terraform registry

### DIFF
--- a/examples/byob/main.tf
+++ b/examples/byob/main.tf
@@ -63,7 +63,8 @@ resource "aws_kms_alias" "key" {
 }
 
 module "resources" {
-  source = "../../modules/file_storage"
+  source  = "wandb/wandb/aws//modules/file_storage"
+  version = "1.5.3"
 
   namespace     = local.namespace
   sse_algorithm = "aws:kms"


### PR DESCRIPTION
#### What does this implement/fix? 
byob example TF uses local path to reference the file storage module. This doesn't work for customers using the byob TF in a separate TF repo.

Instead, reference the module's path in the TF registry.

#### Comments
We might want to use a latest tag in lieu of the v1.5.3 pinned version (latest as of today).
