### PR TITLE
feat: Disable auto scaling for database

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -96,9 +96,7 @@ module "aurora" {
   instance_class = var.instance_class
   instances      = { 1 = {} }
 
-  autoscaling_enabled      = true
-  autoscaling_min_capacity = 1
-  autoscaling_max_capacity = 3
+  autoscaling_enabled      = false
 
   deletion_protection = var.deletion_protection
 


### PR DESCRIPTION
The result of this change would look like the following for **_existing_** installs:
```
Terraform will perform the following actions:

  # module.wandb_infra.module.database.module.aurora.aws_appautoscaling_policy.this[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "aws_appautoscaling_policy" "this" {
      - arn                = "arn:aws:autoscaling:us-west-1:618469898284:scalingPolicy:5be523c8-270f-4165-bd79-042418491195:resource/rds/cluster:disable-auto-scale:policyName/target-metric" -> null
      - id                 = "target-metric" -> null
      - name               = "target-metric" -> null
      - policy_type        = "TargetTrackingScaling" -> null
      - resource_id        = "cluster:disable-auto-scale" -> null
      - scalable_dimension = "rds:cluster:ReadReplicaCount" -> null
      - service_namespace  = "rds" -> null

      - target_tracking_scaling_policy_configuration {
          - disable_scale_in   = false -> null
          - scale_in_cooldown  = 300 -> null
          - scale_out_cooldown = 300 -> null
          - target_value       = 70 -> null

          - predefined_metric_specification {
              - predefined_metric_type = "RDSReaderAverageCPUUtilization" -> null
            }
        }
    }

  # module.wandb_infra.module.database.module.aurora.aws_appautoscaling_target.this[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "aws_appautoscaling_target" "this" {
      - id                 = "cluster:disable-auto-scale" -> null
      - max_capacity       = 3 -> null
      - min_capacity       = 1 -> null
      - resource_id        = "cluster:disable-auto-scale" -> null
      - role_arn           = "arn:aws:iam::618469898284:role/aws-service-role/rds.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_RDSCluster" -> null
      - scalable_dimension = "rds:cluster:ReadReplicaCount" -> null
      - service_namespace  = "rds" -> null
    }
```