### PR TITLE
fix: Fix resource deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,80 +101,95 @@ resources that lack official modules.
 
 ## Requirements
 
-| Name                                                                        | Version |
-| --------------------------------------------------------------------------- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform)    | ~> 1.0  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                      | ~> 3.60 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement_kubernetes) | ~> 2.6  |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.35 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.14 |
 
 ## Providers
 
-| Name                                             | Version |
-| ------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | 3.61.0  |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.35 |
 
 ## Modules
 
-| Name                                                                    | Source                        | Version |
-| ----------------------------------------------------------------------- | ----------------------------- | ------- |
-| <a name="module_acm"></a> [acm](#module_acm)                            | terraform-aws-modules/acm/aws | ~> 3.0  |
-| <a name="module_app_eks"></a> [app_eks](#module_app_eks)                | ./modules/app_eks             | n/a     |
-| <a name="module_app_lb"></a> [app_lb](#module_app_lb)                   | ./modules/app_lb              | n/a     |
-| <a name="module_database"></a> [database](#module_database)             | ./modules/database            | n/a     |
-| <a name="module_file_storage"></a> [file_storage](#module_file_storage) | ./modules/file_storage        | n/a     |
-| <a name="module_kms"></a> [kms](#module_kms)                            | ./modules/kms                 | n/a     |
-| <a name="module_networking"></a> [networking](#module_networking)       | ./modules/networking          | n/a     |
-| <a name="module_redis"></a> [redis](#module_redis)                      | ./modules/redis               | n/a     |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 3.0 |
+| <a name="module_app_eks"></a> [app\_eks](#module\_app\_eks) | ./modules/app_eks | n/a |
+| <a name="module_app_lb"></a> [app\_lb](#module\_app\_lb) | ./modules/app_lb | n/a |
+| <a name="module_database"></a> [database](#module\_database) | ./modules/database | n/a |
+| <a name="module_file_storage"></a> [file\_storage](#module\_file\_storage) | ./modules/file_storage | n/a |
+| <a name="module_kms"></a> [kms](#module\_kms) | ./modules/kms | n/a |
+| <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
+| <a name="module_redis"></a> [redis](#module\_redis) | ./modules/redis | n/a |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
+| [aws_s3_bucket.file_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
+| [aws_sqs_queue.file_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sqs_queue) | data source |
 
 ## Inputs
 
-| Name                                                                                                                        | Description                                                                                                                   | Type           | Default                                                    | Required |
-| --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------------------------------------------------------- | :------: |
-| <a name="input_acm_certificate_arn"></a> [acm_certificate_arn](#input_acm_certificate_arn)                                  | The ARN of an existing ACM certificate.                                                                                       | `string`       | `null`                                                     |    no    |
-| <a name="input_allowed_inbound_cidr"></a> [allowed_inbound_cidr](#input_allowed_inbound_cidr)                               | Allow HTTP(S) traffic to W&B. Defaults to no connections.                                                                     | `list(string)` | `[]`                                                       |    no    |
-| <a name="input_allowed_inbound_ipv6_cidr"></a> [allowed_inbound_ipv6_cidr](#input_allowed_inbound_ipv6_cidr)                | Allow HTTP(S) traffic to W&B. Defaults to no connections.                                                                     | `list(string)` | `[]`                                                       |    no    |
-| <a name="input_create_elasticache"></a> [create_elasticache](#input_create_elasticache)                                     | Boolean indicating whether to create an elasticache instance (true) or not (false).                                           | `bool`         | `false`                                                    |    no    |
-| <a name="input_create_vpc"></a> [create_vpc](#input_create_vpc)                                                             | Boolean indicating whether to deploy a VPC (true) or not (false).                                                             | `bool`         | `true`                                                     |    no    |
-| <a name="input_deletion_protection"></a> [deletion_protection](#input_deletion_protection)                                  | If the instance should have deletion protection enabled. The database / S3 can't be deleted when this value is set to `true`. | `bool`         | `true`                                                     |    no    |
-| <a name="input_domain_name"></a> [domain_name](#input_domain_name)                                                          | Domain for accessing the Weights & Biases UI.                                                                                 | `string`       | n/a                                                        |   yes    |
-| <a name="input_external_dns"></a> [external_dns](#input_external_dns)                                                       | Using external DNS. A `subdomain` must also be specified if this value is true.                                               | `bool`         | `false`                                                    |    no    |
-| <a name="input_kms_key_alias"></a> [kms_key_alias](#input_kms_key_alias)                                                    | KMS key alias for AWS KMS Customer managed key.                                                                               | `string`       | `null`                                                     |    no    |
-| <a name="input_kms_key_deletion_window"></a> [kms_key_deletion_window](#input_kms_key_deletion_window)                      | Duration in days to destroy the key after it is deleted. Must be between 7 and 30 days.                                       | `number`       | `7`                                                        |    no    |
-| <a name="input_kubernetes_public_access"></a> [kubernetes_public_access](#input_kubernetes_public_access)                   | Indicates whether or not the Amazon EKS public API server endpoint is enabled.                                                | `bool`         | `false`                                                    |    no    |
-| <a name="input_kubernetes_public_access_cidrs"></a> [kubernetes_public_access_cidrs](#input_kubernetes_public_access_cidrs) | List of CIDR blocks which can access the Amazon EKS public API server endpoint.                                               | `list(string)` | `[]`                                                       |    no    |
-| <a name="input_namespace"></a> [namespace](#input_namespace)                                                                | String used for prefix resources.                                                                                             | `string`       | n/a                                                        |   yes    |
-| <a name="input_network_cidr"></a> [network_cidr](#input_network_cidr)                                                       | CIDR block for VPC.                                                                                                           | `string`       | `"10.10.0.0/16"`                                           |    no    |
-| <a name="input_network_database_subnet_cidrs"></a> [network_database_subnet_cidrs](#input_network_database_subnet_cidrs)    | List of private subnet CIDR ranges to create in VPC.                                                                          | `list(string)` | <pre>[<br> "10.10.20.0/24",<br> "10.10.21.0/24"<br>]</pre> |    no    |
-| <a name="input_network_database_subnets"></a> [network_database_subnets](#input_network_database_subnets)                   | A list of the identities of the database subnetworks in which resources will be deployed.                                     | `list(string)` | `[]`                                                       |    no    |
-| <a name="input_network_id"></a> [network_id](#input_network_id)                                                             | The identity of the VPC in which resources will be deployed.                                                                  | `string`       | `""`                                                       |    no    |
-| <a name="input_network_private_subnet_cidrs"></a> [network_private_subnet_cidrs](#input_network_private_subnet_cidrs)       | List of private subnet CIDR ranges to create in VPC.                                                                          | `list(string)` | <pre>[<br> "10.10.10.0/24",<br> "10.10.11.0/24"<br>]</pre> |    no    |
-| <a name="input_network_private_subnets"></a> [network_private_subnets](#input_network_private_subnets)                      | A list of the identities of the private subnetworks in which resources will be deployed.                                      | `list(string)` | `[]`                                                       |    no    |
-| <a name="input_network_public_subnet_cidrs"></a> [network_public_subnet_cidrs](#input_network_public_subnet_cidrs)          | List of private subnet CIDR ranges to create in VPC.                                                                          | `list(string)` | <pre>[<br> "10.10.0.0/24",<br> "10.10.1.0/24"<br>]</pre>   |    no    |
-| <a name="input_network_public_subnets"></a> [network_public_subnets](#input_network_public_subnets)                         | A list of the identities of the public subnetworks in which resources will be deployed.                                       | `list(string)` | `[]`                                                       |    no    |
-| <a name="input_public_access"></a> [public_access](#input_public_access)                                                    | Is this instance accessable a public domain.                                                                                  | `bool`         | `false`                                                    |    no    |
-| <a name="input_ssl_policy"></a> [ssl_policy](#input_ssl_policy)                                                             | SSL policy to use on ALB listener                                                                                             | `string`       | `"ELBSecurityPolicy-FS-1-2-Res-2020-10"`                   |    no    |
-| <a name="input_subdomain"></a> [subdomain](#input_subdomain)                                                                | Subdomain for accessing the Weights & Biases UI. Default creates record at Route53 Route.                                     | `string`       | `null`                                                     |    no    |
-| <a name="input_zone_id"></a> [zone_id](#input_zone_id)                                                                      | Domain for creating the Weights & Biases subdomain on.                                                                        | `string`       | n/a                                                        |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_acm_certificate_arn"></a> [acm\_certificate\_arn](#input\_acm\_certificate\_arn) | The ARN of an existing ACM certificate. | `string` | `null` | no |
+| <a name="input_allowed_inbound_cidr"></a> [allowed\_inbound\_cidr](#input\_allowed\_inbound\_cidr) | Allow HTTP(S) traffic to W&B. Defaults to no connections. | `list(string)` | `[]` | no |
+| <a name="input_allowed_inbound_ipv6_cidr"></a> [allowed\_inbound\_ipv6\_cidr](#input\_allowed\_inbound\_ipv6\_cidr) | Allow HTTP(S) traffic to W&B. Defaults to no connections. | `list(string)` | `[]` | no |
+| <a name="input_bucket_kms_key_arn"></a> [bucket\_kms\_key\_arn](#input\_bucket\_kms\_key\_arn) | The Amazon Resource Name of the KMS key with which S3 storage bucket objects will be encrypted. | `string` | `""` | no |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | n/a | `string` | `""` | no |
+| <a name="input_create_elasticache"></a> [create\_elasticache](#input\_create\_elasticache) | Boolean indicating whether to provision an elasticache instance (true) or not (false). | `bool` | `false` | no |
+| <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Boolean indicating whether to deploy a VPC (true) or not (false). | `bool` | `true` | no |
+| <a name="input_database_engine_version"></a> [database\_engine\_version](#input\_database\_engine\_version) | Version for MySQL Auora | `string` | `"8.0.mysql_aurora.3.01.0"` | no |
+| <a name="input_database_instance_class"></a> [database\_instance\_class](#input\_database\_instance\_class) | Instance type to use by database master instance. | `string` | `"db.r5.large"` | no |
+| <a name="input_database_snapshot_identifier"></a> [database\_snapshot\_identifier](#input\_database\_snapshot\_identifier) | Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot | `string` | `null` | no |
+| <a name="input_database_sort_buffer_size"></a> [database\_sort\_buffer\_size](#input\_database\_sort\_buffer\_size) | Specifies the sort\_buffer\_size value to set for the database | `number` | `262144` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | If the instance should have deletion protection enabled. The database / S3 can't be deleted when this value is set to `true`. | `bool` | `true` | no |
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain for accessing the Weights & Biases UI. | `string` | n/a | yes |
+| <a name="input_external_dns"></a> [external\_dns](#input\_external\_dns) | Using external DNS. A `subdomain` must also be specified if this value is true. | `bool` | `false` | no |
+| <a name="input_kms_key_alias"></a> [kms\_key\_alias](#input\_kms\_key\_alias) | KMS key alias for AWS KMS Customer managed key. | `string` | `null` | no |
+| <a name="input_kms_key_deletion_window"></a> [kms\_key\_deletion\_window](#input\_kms\_key\_deletion\_window) | Duration in days to destroy the key after it is deleted. Must be between 7 and 30 days. | `number` | `7` | no |
+| <a name="input_kms_key_policy"></a> [kms\_key\_policy](#input\_kms\_key\_policy) | The policy that will define the permissions for the kms key. | `string` | `""` | no |
+| <a name="input_kubernetes_map_accounts"></a> [kubernetes\_map\_accounts](#input\_kubernetes\_map\_accounts) | Additional AWS account numbers to add to the aws-auth configmap. | `list(string)` | `[]` | no |
+| <a name="input_kubernetes_map_roles"></a> [kubernetes\_map\_roles](#input\_kubernetes\_map\_roles) | Additional IAM roles to add to the aws-auth configmap. | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_kubernetes_map_users"></a> [kubernetes\_map\_users](#input\_kubernetes\_map\_users) | Additional IAM users to add to the aws-auth configmap. | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_kubernetes_public_access"></a> [kubernetes\_public\_access](#input\_kubernetes\_public\_access) | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | `bool` | `false` | no |
+| <a name="input_kubernetes_public_access_cidrs"></a> [kubernetes\_public\_access\_cidrs](#input\_kubernetes\_public\_access\_cidrs) | List of CIDR blocks which can access the Amazon EKS public API server endpoint. | `list(string)` | `[]` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | String used for prefix resources. | `string` | n/a | yes |
+| <a name="input_network_cidr"></a> [network\_cidr](#input\_network\_cidr) | CIDR block for VPC. | `string` | `"10.10.0.0/16"` | no |
+| <a name="input_network_database_subnet_cidrs"></a> [network\_database\_subnet\_cidrs](#input\_network\_database\_subnet\_cidrs) | List of private subnet CIDR ranges to create in VPC. | `list(string)` | <pre>[<br>  "10.10.20.0/24",<br>  "10.10.21.0/24"<br>]</pre> | no |
+| <a name="input_network_database_subnets"></a> [network\_database\_subnets](#input\_network\_database\_subnets) | A list of the identities of the database subnetworks in which resources will be deployed. | `list(string)` | `[]` | no |
+| <a name="input_network_elasticache_subnet_cidrs"></a> [network\_elasticache\_subnet\_cidrs](#input\_network\_elasticache\_subnet\_cidrs) | List of private subnet CIDR ranges to create in VPC. | `list(string)` | <pre>[<br>  "10.10.30.0/24",<br>  "10.10.31.0/24"<br>]</pre> | no |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The identity of the VPC in which resources will be deployed. | `string` | `""` | no |
+| <a name="input_network_private_subnet_cidrs"></a> [network\_private\_subnet\_cidrs](#input\_network\_private\_subnet\_cidrs) | List of private subnet CIDR ranges to create in VPC. | `list(string)` | <pre>[<br>  "10.10.10.0/24",<br>  "10.10.11.0/24"<br>]</pre> | no |
+| <a name="input_network_private_subnets"></a> [network\_private\_subnets](#input\_network\_private\_subnets) | A list of the identities of the private subnetworks in which resources will be deployed. | `list(string)` | `[]` | no |
+| <a name="input_network_public_subnet_cidrs"></a> [network\_public\_subnet\_cidrs](#input\_network\_public\_subnet\_cidrs) | List of private subnet CIDR ranges to create in VPC. | `list(string)` | <pre>[<br>  "10.10.0.0/24",<br>  "10.10.1.0/24"<br>]</pre> | no |
+| <a name="input_network_public_subnets"></a> [network\_public\_subnets](#input\_network\_public\_subnets) | A list of the identities of the public subnetworks in which resources will be deployed. | `list(string)` | `[]` | no |
+| <a name="input_public_access"></a> [public\_access](#input\_public\_access) | Is this instance accessable a public domain. | `bool` | `false` | no |
+| <a name="input_ssl_policy"></a> [ssl\_policy](#input\_ssl\_policy) | SSL policy to use on ALB listener | `string` | `"ELBSecurityPolicy-FS-1-2-Res-2020-10"` | no |
+| <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain for accessing the Weights & Biases UI. Default creates record at Route53 Route. | `string` | `null` | no |
+| <a name="input_use_internal_queue"></a> [use\_internal\_queue](#input\_use\_internal\_queue) | n/a | `bool` | `false` | no |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Domain for creating the Weights & Biases subdomain on. | `string` | n/a | yes |
 
 ## Outputs
 
-| Name                                                                                                              | Description                                                           |
-| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| <a name="output_bucket_name"></a> [bucket_name](#output_bucket_name)                                              | n/a                                                                   |
-| <a name="output_bucket_queue_name"></a> [bucket_queue_name](#output_bucket_queue_name)                            | n/a                                                                   |
-| <a name="output_bucket_region"></a> [bucket_region](#output_bucket_region)                                        | n/a                                                                   |
-| <a name="output_cluster_id"></a> [cluster_id](#output_cluster_id)                                                 | n/a                                                                   |
-| <a name="output_database_connection_string"></a> [database_connection_string](#output_database_connection_string) | n/a                                                                   |
-| <a name="output_internal_app_port"></a> [internal_app_port](#output_internal_app_port)                            | n/a                                                                   |
-| <a name="output_kms_key_arn"></a> [kms_key_arn](#output_kms_key_arn)                                              | The Amazon Resource Name of the KMS key used to encrypt data at rest. |
-| <a name="output_network_id"></a> [network_id](#output_network_id)                                                 | The identity of the VPC in which resources are deployed.              |
-| <a name="output_network_private_subnets"></a> [network_private_subnets](#output_network_private_subnets)          | The identities of the private subnetworks deployed within the VPC.    |
-| <a name="output_network_public_subnets"></a> [network_public_subnets](#output_network_public_subnets)             | The identities of the public subnetworks deployed within the VPC.     |
-| <a name="output_url"></a> [url](#output_url)                                                                      | The URL to the W&B application                                        |
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
+| <a name="output_bucket_queue_name"></a> [bucket\_queue\_name](#output\_bucket\_queue\_name) | n/a |
+| <a name="output_bucket_region"></a> [bucket\_region](#output\_bucket\_region) | n/a |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | n/a |
+| <a name="output_database_connection_string"></a> [database\_connection\_string](#output\_database\_connection\_string) | n/a |
+| <a name="output_elasticache_connection_string"></a> [elasticache\_connection\_string](#output\_elasticache\_connection\_string) | n/a |
+| <a name="output_internal_app_port"></a> [internal\_app\_port](#output\_internal\_app\_port) | n/a |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | The Amazon Resource Name of the KMS key used to encrypt data at rest. |
+| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | The identity of the VPC in which resources are deployed. |
+| <a name="output_network_private_subnets"></a> [network\_private\_subnets](#output\_network\_private\_subnets) | The identities of the private subnetworks deployed within the VPC. |
+| <a name="output_network_public_subnets"></a> [network\_public\_subnets](#output\_network\_public\_subnets) | The identities of the public subnetworks deployed within the VPC. |
+| <a name="output_url"></a> [url](#output\_url) | The URL to the W&B application |
 
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,7 @@ module "app_lb" {
 resource "aws_autoscaling_attachment" "autoscaling_attachment" {
   for_each               = module.app_eks.autoscaling_group_names
   autoscaling_group_name = each.value
-  alb_target_group_arn   = module.app_lb.tg_app_arn
+  lb_target_group_arn    = module.app_lb.tg_app_arn
 }
 
 module "redis" {

--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -107,7 +107,7 @@ resource "aws_iam_role" "node" {
 }
 
 locals {
-  cluster_version = "1.21"
+  cluster_version = "1.23"
 }
 
 module "eks" {

--- a/modules/app_lb/versions.tf
+++ b/modules/app_lb/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.60"
+      version = "~> 4.35"
     }
   }
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -96,7 +96,7 @@ module "aurora" {
   instance_class = var.instance_class
   instances      = { 1 = {} }
 
-  autoscaling_enabled      = false
+  autoscaling_enabled = false
 
   deletion_protection = var.deletion_protection
 

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.60"
+      version = "~> 4.35"
     }
   }
 }

--- a/modules/file_storage/main.tf
+++ b/modules/file_storage/main.tf
@@ -41,7 +41,7 @@ resource "aws_s3_bucket_versioning" "file_storage_version" {
 }
 
 resource "aws_s3_bucket_acl" "file_storage_acl" {
-  bucket = random_pet.file_storage.id
+  bucket = aws_s3_bucket.file_storage.id
   acl    = "private"
 }
 

--- a/modules/file_storage/main.tf
+++ b/modules/file_storage/main.tf
@@ -14,7 +14,21 @@ resource "aws_sqs_queue" "file_storage" {
 
 resource "aws_s3_bucket" "file_storage" {
   bucket = "${var.namespace}-file-storage-${random_pet.file_storage.id}"
-  acl    = "private"
+  
+  force_destroy = !var.deletion_protection
+
+  # Configuration error if SQS does not exist
+  # https://aws.amazon.com/premiumsupport/knowledge-center/unable-validate-destination-s3/
+  depends_on = [aws_sqs_queue.file_storage]
+}
+
+resource "aws_s3_bucket_acl" "s3_acl" {
+  bucket = random_pet.file_storage.id
+  acl = "private"
+}
+
+resource "aws_s3_bucket_cors_configuration" "cors" {
+  bucket = aws_s3_bucket.file_storage.id
 
   cors_rule {
     allowed_headers = ["*"]
@@ -23,21 +37,17 @@ resource "aws_s3_bucket" "file_storage" {
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
   }
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = var.kms_key_arn
-        sse_algorithm     = var.sse_algorithm
-      }
+resource "aws_s3_bucket_server_side_encryption_configuration" "s3_encryption" {
+  bucket = aws_s3_bucket.file_storage.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = var.kms_key_arn
+      sse_algorithm     = var.sse_algorithm
     }
   }
-
-  force_destroy = !var.deletion_protection
-
-  # Configuration error if SQS does not exist
-  # https://aws.amazon.com/premiumsupport/knowledge-center/unable-validate-destination-s3/
-  depends_on = [aws_sqs_queue.file_storage]
 }
 
 resource "aws_s3_bucket_public_access_block" "file_storage" {

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.60"
+      version = "~> 4.35"
     }
   }
 }

--- a/modules/networking/versions.tf
+++ b/modules/networking/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.60"
+      version = "~> 4.35"
     }
   }
 }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -5,7 +5,7 @@ locals {
 resource "aws_elasticache_replication_group" "default" {
   replication_group_id          = "${var.namespace}-rep-group"
   replication_group_description = "${var.namespace}-rep-group"
-  number_cache_clusters         = 2
+  num_cache_clusters            = 2
   port                          = 6379
 
   node_type            = "cache.t2.medium"

--- a/modules/redis/versions.tf
+++ b/modules/redis/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.60"
+      version = "~> 4.35"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.60"
+      version = "~> 4.35"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.6"
+      version = "~> 2.14"
     }
   }
 }


### PR DESCRIPTION
The PR is intended to fix some deprecations on the S3 resource. The deprecations are listed below.

```
╷
│ Warning: Argument is deprecated
│
│   with module.wandb_infra.module.file_storage.aws_s3_bucket.file_storage,
│   on ../terraform-aws-wandb/modules/file_storage/main.tf line 15, in resource "aws_s3_bucket" "file_storage":
│   15: resource "aws_s3_bucket" "file_storage" {
│
│ Use the aws_s3_bucket_cors_configuration resource instead
│
│ (and 5 more similar warnings elsewhere)
╵
```

```
╷
│ Warning: Argument is deprecated
│
│   with module.wandb_infra.module.file_storage.aws_s3_bucket.file_storage,
│   on ../terraform-aws-wandb/modules/file_storage/main.tf line 15, in resource "aws_s3_bucket" "file_storage":
│   15: resource "aws_s3_bucket" "file_storage" {
│
│ Use the aws_s3_bucket_server_side_encryption_configuration resource instead
│
│ (and 3 more similar warnings elsewhere)
╵
```

```
╷
│ Warning: Argument is deprecated
│
│   with module.wandb_infra.module.file_storage.aws_s3_bucket.file_storage,
│   on ../terraform-aws-wandb/modules/file_storage/main.tf line 17, in resource "aws_s3_bucket" "file_storage":
│   17:   acl    = "private"
│
│ Use the aws_s3_bucket_acl resource instead
│
│ (and one more similar warning elsewhere)
╵
```
