### PR TITLE
fix: IMDSv2 for node groups and encrypt EBS volumes

### DIFF
--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -133,12 +133,14 @@ module "eks" {
 
   node_groups = {
     primary = {
-      version          = var.cluster_version
-      desired_capacity = 2,
-      max_capacity     = 5,
-      min_capacity     = 2,
-      instance_type    = ["m5.xlarge"],
-      iam_role_arn     = aws_iam_role.node.arn
+      version                = var.cluster_version
+      desired_capacity       = 2,
+      max_capacity           = 5,
+      min_capacity           = 2,
+      instance_type          = ["m5.xlarge"],
+      iam_role_arn           = aws_iam_role.node.arn
+      create_launch_template = true
+      metadata_http_tokens   = "required"
     }
   }
 

--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -140,6 +140,8 @@ module "eks" {
       instance_type          = ["m5.xlarge"],
       iam_role_arn           = aws_iam_role.node.arn
       create_launch_template = true
+      disk_encrypted         = true
+      disk_kms_key_id        = var.kms_key_arn
       metadata_http_tokens   = "required"
     }
   }


### PR DESCRIPTION
- Requires IMDSv2 by setting metadata_http_tokens to required
- Encrypt EBS volumes by setting encrypt_disk to true and setting KMS key ID to the passed in KMS key

TODO: testing