### PR TITLE
Zacharyb/distinct

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -150,7 +150,7 @@ module "app_eks" {
   cluster_endpoint_public_access       = var.kubernetes_public_access
   cluster_endpoint_public_access_cidrs = var.kubernetes_public_access_cidrs
 
-  eks_policy_arns = toset(var.eks_policy_arns)
+  eks_policy_arns = distinct(var.eks_policy_arns)
 }
 
 module "app_lb" {

--- a/modules/app_lb/main.tf
+++ b/modules/app_lb/main.tf
@@ -148,7 +148,7 @@ resource "aws_route53_record" "alb" {
 }
 
 resource "aws_route53_record" "extra" {
-  for_each = toset(var.extra_fqdn)
+  for_each = distinct(var.extra_fqdn)
   zone_id = var.zone_id
   name    = each.value
   type    = "A"


### PR DESCRIPTION
https://developer.hashicorp.com/terraform/language/functions/distinct 
https://developer.hashicorp.com/terraform/language/functions/toset

Set collections are unordered and cannot contain duplicate values, so the ordering of the argument elements is lost and any duplicate values are coalesced:

distinct takes a list and returns a new list with any duplicate elements removed.
The first occurrence of each value is retained and the relative ordering of these elements is preserved.