### PR TITLE
fix: Put rules for inbound HTTP/HTTPS into their own security groups

### DIFF
--- a/examples/byob/README.md
+++ b/examples/byob/README.md
@@ -88,8 +88,11 @@ Lastly, you'll need to create the S3 bucket. Make sure to enable CORS access. Yo
 <CORSRule>
     <AllowedOrigin>*</AllowedOrigin>
     <AllowedMethod>GET</AllowedMethod>
+    <AllowedMethod>HEAD</AllowedMethod>
     <AllowedMethod>PUT</AllowedMethod>
     <AllowedHeader>*</AllowedHeader>
+    <ExposeHeader>ETag</ExposeHeader>
+    <MaxAgeSeconds>3000</MaxAgeSeconds>
 </CORSRule>
 </CORSConfiguration>
 ```

--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -66,6 +66,7 @@ module "wandb_app" {
   bucket_queue               = "internal://"
   bucket_kms_key_arn         = module.wandb_infra.kms_key_arn
   database_connection_string = "mysql://${module.wandb_infra.database_connection_string}"
+  redis_connection_string    = "redis://${module.wandb_infra.elasticache_connection_string}?tls=true&ttlInSeconds=604800"
 
   wandb_image   = var.wandb_image
   wandb_version = var.wandb_version

--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -25,7 +25,7 @@ module "wandb_infra" {
   database_snapshot_identifier = var.database_snapshot_identifier
   database_sort_buffer_size    = var.database_sort_buffer_size
 
-  allowed_inbound_cidr      = ["0.0.0.0/0"]
+  allowed_inbound_cidr      = var.allowed_inbound_cidr
   allowed_inbound_ipv6_cidr = ["::/0"]
 
   eks_cluster_version            = "1.24"

--- a/examples/public-dns-external/variables.tf
+++ b/examples/public-dns-external/variables.tf
@@ -74,3 +74,10 @@ variable "bucket_kms_key_arn" {
   description = "The Amazon Resource Name of the KMS key with which S3 storage bucket objects will be encrypted."
   default     = ""
 }
+
+
+variable "allowed_inbound_cidr" {
+  default  = ["0.0.0.0/0"]
+  nullable = false
+  type     = list(string)
+}

--- a/main.tf
+++ b/main.tf
@@ -27,8 +27,8 @@ module "file_storage" {
 }
 
 locals {
-  bucket_name       = local.use_external_bucket ? var.bucket_name : module.file_storage.0.bucket_name 
-  bucket_queue_name = local.use_internal_queue ? null : module.file_storage.0.bucket_queue_name 
+  bucket_name       = local.use_external_bucket ? var.bucket_name : module.file_storage.0.bucket_name
+  bucket_queue_name = local.use_internal_queue ? null : module.file_storage.0.bucket_queue_name
 }
 
 data "aws_s3_bucket" "file_storage" {
@@ -140,8 +140,8 @@ module "app_eks" {
   network_id              = local.network_id
   network_private_subnets = local.network_private_subnets
 
-  lb_security_group_inbound_id = module.app_lb.security_group_inbound_id
-  database_security_group_id   = module.database.security_group_id
+  lb_inbound_security_group_ids = module.app_lb.inbound_security_group_ids
+  database_security_group_id    = module.database.security_group_id
 
   create_elasticache_security_group = var.create_elasticache
   elasticache_security_group_id     = var.create_elasticache ? module.redis.0.security_group_id : null
@@ -186,7 +186,7 @@ module "redis" {
   vpc_id                  = local.network_id
   redis_subnet_group_name = local.network_elasticache_subnet_group_name
   vpc_subnets_cidr_blocks = module.networking.elasticache_subnet_cidrs
-  node_type              = var.elasticache_node_type
+  node_type               = var.elasticache_node_type
 
   kms_key_arn = local.kms_key_arn
 }

--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -140,9 +140,9 @@ resource "aws_iam_role" "node" {
 }
 
 resource "aws_iam_role_policy_attachment" "node" {
-    for_each   =  var.eks_policy_arns
-    role       = aws_iam_role.node.name
-    policy_arn = each.value
+  for_each   = var.eks_policy_arns
+  role       = aws_iam_role.node.name
+  policy_arn = each.value
 }
 
 module "eks" {
@@ -205,10 +205,11 @@ resource "aws_security_group" "primary_workers" {
 }
 
 resource "aws_security_group_rule" "lb" {
+  count                    = length(var.lb_inbound_security_group_ids)
   description              = "Allow container NodePort service to receive load balancer traffic."
   protocol                 = "tcp"
   security_group_id        = aws_security_group.primary_workers.id
-  source_security_group_id = var.lb_security_group_inbound_id
+  source_security_group_id = var.lb_inbound_security_group_ids[count.index]
   from_port                = var.service_port
   to_port                  = var.service_port
   type                     = "ingress"

--- a/modules/app_eks/variables.tf
+++ b/modules/app_eks/variables.tf
@@ -1,23 +1,19 @@
-variable "namespace" {
-  type        = string
-  description = "(Required) The name prefix for all resources created."
+variable "bucket_arn" {
+  type = string
 }
 
-variable "network_id" {
-  description = "(Required) The identity of the VPC in which the security group attached to the MySQL Aurora instances will be deployed."
+
+variable "bucket_kms_key_arn" {
+  description = "The Amazon Resource Name of the KMS key with which S3 storage bucket objects will be encrypted."
   type        = string
 }
 
-variable "network_private_subnets" {
-  description = "(Required) A list of the identities of the private subnetworks in which the MySQL Aurora instances will be deployed."
-  type        = list(string)
+
+variable "bucket_sqs_queue_arn" {
+  type    = string
+  default = null
 }
 
-variable "cluster_version" {
-  description = "Indicates AWS EKS cluster version"
-  type        = string
-  default     = "1.21"
-}
 
 variable "cluster_endpoint_public_access" {
   type        = bool
@@ -25,34 +21,44 @@ variable "cluster_endpoint_public_access" {
   default     = true
 }
 
+
 variable "cluster_endpoint_public_access_cidrs" {
   description = "List of CIDR blocks which can access the Amazon EKS public API server endpoint."
   type        = list(string)
   default     = []
 }
 
-variable "lb_security_group_inbound_id" {
+
+variable "cluster_version" {
+  description = "Indicates AWS EKS cluster version"
+  type        = string
+  default     = "1.21"
+}
+
+
+variable "create_elasticache_security_group" {
+  type    = bool
+  default = false
+}
+
+
+variable "database_security_group_id" {
   type = string
 }
 
-variable "bucket_arn" {
-  type = string
+
+variable "eks_policy_arns" {
+  description = "Additional IAM policy to apply to the EKS cluster"
+  type        = set(string)
+  default     = []
 }
 
-variable "bucket_sqs_queue_arn" {
+
+variable "elasticache_security_group_id" {
   type    = string
   default = null
 }
 
-variable "bucket_kms_key_arn" {
-  description = "The Amazon Resource Name of the KMS key with which S3 storage bucket objects will be encrypted."
-  type        = string
-}
-
-variable "kms_key_arn" {
-  description = "(Required) The Amazon Resource Name of the KMS key with which EKS secrets will be encrypted."
-  type        = string
-}
 
 variable "instance_types" {
   description = "EC2 Instance type for primary node group."
@@ -60,30 +66,26 @@ variable "instance_types" {
   default     = ["m4.large"]
 }
 
-variable "database_security_group_id" {
-  type = string
+
+variable "kms_key_arn" {
+  description = "(Required) The Amazon Resource Name of the KMS key with which EKS secrets will be encrypted."
+  type        = string
 }
 
-variable "elasticache_security_group_id" {
-  type    = string
-  default = null
+
+variable "lb_inbound_security_group_ids" {
+  description = "IDs of security groups to be associated with the loadbalancer."
+  nullable    = false
+  type        = list(string)
 }
 
-variable "create_elasticache_security_group" {
-  type    = bool
-  default = false
-}
-
-variable "service_port" {
-  type    = number
-  default = 32543
-}
 
 variable "map_accounts" {
   description = "Additional AWS account numbers to add to the aws-auth configmap. See examples/basic/variables.tf for example format."
   type        = list(string)
   default     = []
 }
+
 
 variable "map_roles" {
   description = "Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format."
@@ -95,6 +97,7 @@ variable "map_roles" {
   default = []
 }
 
+
 variable "map_users" {
   description = "Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format."
   type = list(object({
@@ -105,8 +108,28 @@ variable "map_users" {
   default = []
 }
 
-variable "eks_policy_arns" {
-  description = "Additional IAM policy to apply to the EKS cluster"
-  type        = set(string)
-  default     = []
+
+variable "namespace" {
+  type        = string
+  description = "(Required) The name prefix for all resources created."
 }
+
+
+variable "network_id" {
+  description = "(Required) The identity of the VPC in which the security group attached to the MySQL Aurora instances will be deployed."
+  type        = string
+}
+
+
+variable "network_private_subnets" {
+  description = "(Required) A list of the identities of the private subnetworks in which the MySQL Aurora instances will be deployed."
+  type        = list(string)
+}
+
+
+variable "service_port" {
+  type    = number
+  default = 32543
+}
+
+

--- a/modules/app_lb/main.tf
+++ b/modules/app_lb/main.tf
@@ -18,7 +18,7 @@ resource "aws_security_group" "inbound-http" {
   description = "Allow http traffic to wandb"
   vpc_id      = var.network_id
 
- ingress {
+  ingress {
     from_port        = local.http_port
     to_port          = local.http_port
     protocol         = "tcp"
@@ -63,7 +63,7 @@ resource "aws_lb" "alb" {
   name               = "${var.namespace}-alb"
   internal           = (var.load_balancing_scheme == "PRIVATE")
   load_balancer_type = "application"
-  security_groups    = [aws_security_group.aws_security_group.inbound-https.id, aws_security_group.inbound-http.id, aws_security_group.outbound.id]
+  security_groups    = [aws_security_group.inbound-https.id, aws_security_group.inbound-http.id, aws_security_group.outbound.id]
   subnets            = var.load_balancing_scheme == "PRIVATE" ? var.network_private_subnets : var.network_public_subnets
 }
 
@@ -167,9 +167,9 @@ resource "aws_route53_record" "alb" {
 
 resource "aws_route53_record" "extra" {
   for_each = toset(var.extra_fqdn)
-  zone_id = var.zone_id
-  name    = each.value
-  type    = "A"
+  zone_id  = var.zone_id
+  name     = each.value
+  type     = "A"
 
   alias {
     name                   = aws_lb.alb.dns_name

--- a/modules/app_lb/main.tf
+++ b/modules/app_lb/main.tf
@@ -13,8 +13,8 @@ locals {
 // can easily exceed 100. 
 // -> george.scott@wandb.com :: 2023-06-20
 ////////////////////////////////////////////////////////////////////////////////////////////
-resource "aws_security_group" "inbound-http" {
-  name        = "${var.namespace}-alb-inbound-http"
+resource "aws_security_group" "inbound_http" {
+  name        = "${var.namespace}-alb-inbound_http"
   description = "Allow http traffic to wandb"
   vpc_id      = var.network_id
 
@@ -28,8 +28,8 @@ resource "aws_security_group" "inbound-http" {
   }
 }
 
-resource "aws_security_group" "inbound-https" {
-  name        = "${var.namespace}-alb-inbound-https"
+resource "aws_security_group" "inbound_https" {
+  name        = "${var.namespace}-alb-inbound_https"
   description = "Allow https traffic to wandb"
   vpc_id      = var.network_id
 
@@ -63,7 +63,7 @@ resource "aws_lb" "alb" {
   name               = "${var.namespace}-alb"
   internal           = (var.load_balancing_scheme == "PRIVATE")
   load_balancer_type = "application"
-  security_groups    = [aws_security_group.inbound-https.id, aws_security_group.inbound-http.id, aws_security_group.outbound.id]
+  security_groups    = [aws_security_group.inbound_https.id, aws_security_group.inbound_http.id, aws_security_group.outbound.id]
   subnets            = var.load_balancing_scheme == "PRIVATE" ? var.network_private_subnets : var.network_public_subnets
 }
 

--- a/modules/app_lb/main.tf
+++ b/modules/app_lb/main.tf
@@ -14,8 +14,8 @@ locals {
 // -> george.scott@wandb.com :: 2023-06-20
 ////////////////////////////////////////////////////////////////////////////////////////////
 resource "aws_security_group" "inbound-http" {
-  name        = "${var.namespace}-alb-inbound"
-  description = "Allow http(s) traffic to wandb"
+  name        = "${var.namespace}-alb-inbound-http"
+  description = "Allow http traffic to wandb"
   vpc_id      = var.network_id
 
  ingress {
@@ -29,8 +29,8 @@ resource "aws_security_group" "inbound-http" {
 }
 
 resource "aws_security_group" "inbound-https" {
-  name        = "${var.namespace}-alb-inbound"
-  description = "Allow http(s) traffic to wandb"
+  name        = "${var.namespace}-alb-inbound-https"
+  description = "Allow https traffic to wandb"
   vpc_id      = var.network_id
 
   ingress {

--- a/modules/app_lb/main.tf
+++ b/modules/app_lb/main.tf
@@ -3,7 +3,32 @@ locals {
   https_port = 443
 }
 
-resource "aws_security_group" "inbound" {
+
+////////////////////////////////////////////////////////////////////////////////////////////
+// the following security group definitions are created to handle a situation where 
+// we need to assign a large number of ips to a SG, such as is the case in 
+// https://wandb.atlassian.net/browse/WB-14096.
+// althought the quota for max # of security group rules per security group has been raised
+// to 100 as of 2023-06-20, if we don't separate HTTP/HTTPS, the sum number of rules
+// can easily exceed 100. 
+// -> george.scott@wandb.com :: 2023-06-20
+////////////////////////////////////////////////////////////////////////////////////////////
+resource "aws_security_group" "inbound-http" {
+  name        = "${var.namespace}-alb-inbound"
+  description = "Allow http(s) traffic to wandb"
+  vpc_id      = var.network_id
+
+ ingress {
+    from_port        = local.http_port
+    to_port          = local.http_port
+    protocol         = "tcp"
+    description      = "Allow HTTP (port ${local.http_port}) traffic inbound to W&B LB"
+    cidr_blocks      = var.allowed_inbound_cidr
+    ipv6_cidr_blocks = var.allowed_inbound_ipv6_cidr
+  }
+}
+
+resource "aws_security_group" "inbound-https" {
   name        = "${var.namespace}-alb-inbound"
   description = "Allow http(s) traffic to wandb"
   vpc_id      = var.network_id
@@ -16,16 +41,9 @@ resource "aws_security_group" "inbound" {
     cidr_blocks      = var.allowed_inbound_cidr
     ipv6_cidr_blocks = var.allowed_inbound_ipv6_cidr
   }
-
-  ingress {
-    from_port        = local.http_port
-    to_port          = local.http_port
-    protocol         = "tcp"
-    description      = "Allow HTTP (port ${local.http_port}) traffic inbound to W&B LB"
-    cidr_blocks      = var.allowed_inbound_cidr
-    ipv6_cidr_blocks = var.allowed_inbound_ipv6_cidr
-  }
 }
+
+
 
 resource "aws_security_group" "outbound" {
   name        = "${var.namespace}-alb-outbound"
@@ -45,7 +63,7 @@ resource "aws_lb" "alb" {
   name               = "${var.namespace}-alb"
   internal           = (var.load_balancing_scheme == "PRIVATE")
   load_balancer_type = "application"
-  security_groups    = [aws_security_group.inbound.id, aws_security_group.outbound.id]
+  security_groups    = [aws_security_group.aws_security_group.inbound-https.id, aws_security_group.inbound-http.id, aws_security_group.outbound.id]
   subnets            = var.load_balancing_scheme == "PRIVATE" ? var.network_private_subnets : var.network_public_subnets
 }
 

--- a/modules/app_lb/outputs.tf
+++ b/modules/app_lb/outputs.tf
@@ -2,14 +2,28 @@ output "dns_name" {
   value = aws_lb.alb.dns_name
 }
 
-output "security_group_inbound_id" {
-  value = aws_security_group.inbound.id
+
+output "inbound_security_group_ids" {
+  value = tolist([aws_security_group.inbound-http.id, aws_security_group.inbound-https.id])
 }
+
 
 output "lb_arn" {
   value = aws_lb.alb.arn
 }
 
+
+output "security_group_inbound_http_id" {
+  value = aws_security_group.inbound-http.id
+}
+
+
+output "security_group_inbound_https_id" {
+  value = aws_security_group.inbound-https.id
+}
+
+
 output "tg_app_arn" {
   value = aws_lb_target_group.app.arn
 }
+

--- a/modules/app_lb/outputs.tf
+++ b/modules/app_lb/outputs.tf
@@ -4,7 +4,7 @@ output "dns_name" {
 
 
 output "inbound_security_group_ids" {
-  value = tolist([aws_security_group.inbound-http.id, aws_security_group.inbound-https.id])
+  value = tolist([aws_security_group.inbound_http.id, aws_security_group.inbound_https.id])
 }
 
 
@@ -14,12 +14,12 @@ output "lb_arn" {
 
 
 output "security_group_inbound_http_id" {
-  value = aws_security_group.inbound-http.id
+  value = aws_security_group.inbound_http.id
 }
 
 
 output "security_group_inbound_https_id" {
-  value = aws_security_group.inbound-https.id
+  value = aws_security_group.inbound_https.id
 }
 
 

--- a/modules/secure_storage_connector/main.tf
+++ b/modules/secure_storage_connector/main.tf
@@ -27,7 +27,7 @@ resource "aws_kms_key" "key" {
           "kms:ReEncrypt*",
           "kms:GenerateDataKey*"
         ],
-        Resource: "*"
+        Resource : "*"
       }
     ]
   })
@@ -79,5 +79,5 @@ resource "aws_s3_bucket_policy" "s3_policy" {
 }
 
 data "aws_s3_bucket" "file_storage" {
-  bucket     = module.file_storage.bucket_name
+  bucket = module.file_storage.bucket_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -113,7 +113,8 @@ variable "acm_certificate_arn" {
 
 variable "allowed_inbound_cidr" {
   type        = list(string)
-  default     = []
+  default     = ["0.0.0.0/0"]
+  nullable    = false
   description = "Allow HTTP(S) traffic to W&B. Defaults to no connections."
 }
 
@@ -260,7 +261,7 @@ variable "kubernetes_instance_types" {
   description = "EC2 Instance type for primary node group."
   type        = list(string)
   default     = ["m4.large"]
- }
+}
 
 variable "eks_policy_arns" {
   type        = list(string)


### PR DESCRIPTION
This to allow us to workaround the AWS quotas on max # of rules per security group (100). 