### PR TITLE
feat!: Enable cloudwatch log group creation rds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Weights & Biases AWS Module
 
+## BREAKING CHANGE ##
+This version upgrades key terraform providers. Existing installations _must_ be upgraded the v1.16.8
+BEFORE upgrading to this version.
+
 **IMPORTANT:** You are viewing a beta version of the official module to install
 Weights & Biases. This new version is incompatible with earlier versions, and it
 is not currently meant for production use. Please contact your Customer Success

--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -26,6 +26,10 @@ module "wandb_infra" {
   database_sort_buffer_size    = var.database_sort_buffer_size
 
   allowed_inbound_cidr      = var.allowed_inbound_cidr
+  /////////////////////////////////////////////////////////////
+  // this defaults to all, which allows the ELB to reached
+  // by IPv6 from any origin. to block IPv6, set this to "::/1".
+  ////////////////////////////////////////////////////////////
   allowed_inbound_ipv6_cidr = ["::/0"]
 
   eks_cluster_version            = "1.24"

--- a/examples/public-dns-external/versions.tf
+++ b/examples/public-dns-external/versions.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/main.tf
+++ b/main.tf
@@ -175,7 +175,7 @@ module "app_lb" {
 resource "aws_autoscaling_attachment" "autoscaling_attachment" {
   for_each               = module.app_eks.autoscaling_group_names
   autoscaling_group_name = each.value
-  alb_target_group_arn   = module.app_lb.tg_app_arn
+  lb_target_group_arn    = module.app_lb.tg_app_arn
 }
 
 module "redis" {

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ locals {
 # Create SSL Ceritifcation if applicable
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
-  version = "~> 3.0"
+  version = ">= 3.0"
 
   create_certificate = local.create_certificate
 

--- a/modules/app_eks/iam-policy-docs.tf
+++ b/modules/app_eks/iam-policy-docs.tf
@@ -1,6 +1,5 @@
 data "aws_iam_policy_document" "node_cloudwatch" {
   statement {
-    sid       = "bb2"
     actions   = ["cloudwatch:PutMetricData"]
     effect    = "Allow"
     resources = ["*"]
@@ -10,7 +9,6 @@ data "aws_iam_policy_document" "node_cloudwatch" {
 
 data "aws_iam_policy_document" "node_IMDSv2" {
   statement {
-    sid       = "cc3"
     actions   = ["ec2:DescribeInstanceAttribute"]
     effect    = "Allow"
     resources = ["*"]
@@ -20,7 +18,6 @@ data "aws_iam_policy_document" "node_IMDSv2" {
 // todo: refactor --> v1.16.3
 data "aws_iam_policy_document" "node_kms" {
   statement {
-    sid = "dd4"
     actions = [
       "kms:Encrypt",
       "kms:Decrypt",
@@ -37,7 +34,6 @@ data "aws_iam_policy_document" "node_kms" {
 // todo: refactor --> v1.16.3
 data "aws_iam_policy_document" "node_sqs" {
   statement {
-    sid       = "ee5"
     actions   = ["sqs:*"]
     effect    = "Allow"
     resources = var.bucket_sqs_queue_arn == "" || var.bucket_sqs_queue_arn == null ? ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${aws_iam_role.node.name}"] : [var.bucket_sqs_queue_arn]
@@ -47,7 +43,6 @@ data "aws_iam_policy_document" "node_sqs" {
 
 data "aws_iam_policy_document" "node_s3" {
   statement {
-    sid     = "ff6"
     actions = ["s3:*"]
     effect  = "Allow"
     resources = [

--- a/modules/app_eks/iam-roles.tf
+++ b/modules/app_eks/iam-roles.tf
@@ -2,8 +2,7 @@ resource "aws_iam_role" "node" {
   name               = "${var.namespace}-node"
   assume_role_policy = data.aws_iam_policy_document.node_assume.json
 
-  // todo: refactor --> v1.16.3
-  inline_policy {}
+
 }
 
 

--- a/modules/app_eks/iam-roles.tf
+++ b/modules/app_eks/iam-roles.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "node" {
   name               = "${var.namespace}-node"
   assume_role_policy = data.aws_iam_policy_document.node_assume.json
-  
+
   // todo: refactor --> v1.16.3
   inline_policy {}
 }

--- a/modules/app_lb/versions.tf
+++ b/modules/app_lb/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -96,34 +96,34 @@ resource "aws_rds_cluster_parameter_group" "default" {
 
 module "aurora" {
   source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "6.2.0"
+  version = "7.7.1"
 
-  allow_major_version_upgrade           = true
-  allowed_cidr_blocks                   = var.allowed_cidr_blocks
-  apply_immediately                     = true
-  autoscaling_enabled                   = false
-  backup_retention_period               = var.backup_retention_period
-  create_db_subnet_group                = var.create_db_subnet_group
-  create_random_password                = false
-  create_security_group                 = true
-  database_name                         = var.database_name
-  db_cluster_parameter_group_name       = aws_rds_cluster_parameter_group.default.id
-  db_parameter_group_name               = aws_db_parameter_group.default.id
-  db_subnet_group_name                  = var.db_subnet_group_name
-  deletion_protection                   = var.deletion_protection
-  enabled_cloudwatch_logs_exports       = ["audit", "error", "general", "slowquery"]
-  engine                                = "aurora-mysql"
-  engine_version                        = var.engine_version
-  iam_database_authentication_enabled   = false
-  iam_role_force_detach_policies        = true
-  iam_role_name                         = "${var.namespace}-aurora-monitoring"
-  instance_class                        = var.instance_class
-  instances                             = { 1 = {} }
-  kms_key_id                            = var.kms_key_arn
-  master_password                       = local.master_password
-  master_username                       = var.master_username
-  monitoring_interval                   = 15
-  name                                  = var.namespace
+  allow_major_version_upgrade         = true
+  allowed_cidr_blocks                 = var.allowed_cidr_blocks
+  apply_immediately                   = true
+  autoscaling_enabled                 = false
+  backup_retention_period             = var.backup_retention_period
+  create_db_subnet_group              = var.create_db_subnet_group
+  create_random_password              = false
+  create_security_group               = true
+  database_name                       = var.database_name
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.default.id
+  db_parameter_group_name             = aws_db_parameter_group.default.id
+  db_subnet_group_name                = var.db_subnet_group_name
+  deletion_protection                 = var.deletion_protection
+  enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
+  engine                              = "aurora-mysql"
+  engine_version                      = var.engine_version
+  iam_database_authentication_enabled = false
+  iam_role_force_detach_policies      = true
+  iam_role_name                       = "${var.namespace}-aurora-monitoring"
+  instance_class                      = var.instance_class
+  instances                           = { 1 = {} }
+  kms_key_id                          = var.kms_key_arn
+  master_password                     = local.master_password
+  master_username                     = var.master_username
+  monitoring_interval                 = 15
+  name                                = var.namespace
   ////////////////////////////////////////////////////////////////////////////////////////
   // !!! note on performance insights !!!
   // AWS offers 7 days of performance insights free. keeping them after this period
@@ -141,5 +141,5 @@ module "aurora" {
   subnets                               = var.subnets
   vpc_id                                = var.vpc_id
 
-  
+
 }

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -4,7 +4,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = ">= 3.0"
 
   create_vpc = var.create_vpc
 

--- a/modules/networking/versions.tf
+++ b/modules/networking/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,27 +1,19 @@
-locals {
-  redis_version = "6.x"
-}
-
 resource "aws_elasticache_replication_group" "default" {
-  replication_group_id          = "${var.namespace}-rep-group"
-  replication_group_description = "${var.namespace}-rep-group"
-  number_cache_clusters         = 2
-  port                          = 6379
-
-  node_type            = var.node_type
-  parameter_group_name = "default.redis6.x"
-  engine_version       = local.redis_version
-
-  automatic_failover_enabled = true
-  multi_az_enabled           = true
-  maintenance_window         = var.preferred_maintenance_window
-  snapshot_retention_limit   = 1
-
-  subnet_group_name  = var.redis_subnet_group_name
-  security_group_ids = [aws_security_group.redis.id]
-
-  kms_key_id                 = var.kms_key_arn
   at_rest_encryption_enabled = true
+  automatic_failover_enabled = true
+  description                = "${var.namespace}-rep-group"
+  engine_version             = "6.x"
+  kms_key_id                 = var.kms_key_arn
+  maintenance_window         = var.preferred_maintenance_window
+  multi_az_enabled           = true
+  node_type                  = var.node_type
+  num_cache_clusters         = 2
+  parameter_group_name       = "default.redis6.x"
+  port                       = 6379
+  replication_group_id       = "${var.namespace}-rep-group"
+  security_group_ids         = [aws_security_group.redis.id]
+  snapshot_retention_limit   = 1
+  subnet_group_name          = var.redis_subnet_group_name
   transit_encryption_enabled = true
 }
 
@@ -31,19 +23,19 @@ resource "aws_security_group" "redis" {
 }
 
 resource "aws_security_group_rule" "ingress" {
-  type              = "ingress"
-  protocol          = "tcp"
-  from_port         = "6379"
-  to_port           = "6379"
   cidr_blocks       = var.vpc_subnets_cidr_blocks
+  from_port         = "6379"
+  protocol          = "tcp"
   security_group_id = aws_security_group.redis.id
+  to_port           = "6379"
+  type              = "ingress"
 }
 
 resource "aws_security_group_rule" "egress" {
-  type              = "egress"
-  protocol          = "tcp"
-  from_port         = "6379"
-  to_port           = "6379"
   cidr_blocks       = var.vpc_subnets_cidr_blocks
+  from_port         = "6379"
+  protocol          = "tcp"
   security_group_id = aws_security_group.redis.id
+  to_port           = "6379"
+  type              = "egress"
 }

--- a/modules/redis/versions.tf
+++ b/modules/redis/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/secure_storage_connector/versions.tf
+++ b/modules/secure_storage_connector/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/versions.tf
+++ b/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.60"
+      version = ">= 4.00"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.6"
+      version = ">= 2.6"
     }
   }
 }


### PR DESCRIPTION
This is a breaking change. It is advised that all wandb instances managed using this terraform be upgrade to v.1.16.8 *prior* to upgrading this version. There is no direct upgrade path from versions < 1.16.8 to this version.

The following providers are updated to the indicated major release:
- AWS: version 5
- AWS Aurora: version 7

This is to address an issue with older versions of the Aurora provider in particular which do not create the required cloudwatch log groups, when logging is enabled. Version 7 of the Aurora provider requires a more recent version of the AWS provider.

ADDITIONAL CHANGES:
The "sid" element is removed from aws_iam_policy_document resource types, which should reduce the amount of churn during terraform plans and applies. 

It should be noted here that the default value for "allowed_inbound_ipv6_cidr" is `["::/0"]`. This pertains to the load balancer only, and indicates that traffic from any IPv6 source is allowed. To restrict traffice, either provide an IPv6 cidr, or use `[ "::/1" ]`, which restricts IPv6 traffic to the localhost. This informs the security group that IPv6 traffic to the load balancer will only be allowed if it originate with the load balancer.

A notice has been added to the root level README document re: the breaking change.