### PR TITLE
feat!: AWS Provider Upgrade

### DIFF
--- a/examples/public-dns-external/versions.tf
+++ b/examples/public-dns-external/versions.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/examples/public-dns-with-route53/versions.tf
+++ b/examples/public-dns-with-route53/versions.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/app_lb/versions.tf
+++ b/modules/app_lb/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/networking/versions.tf
+++ b/modules/networking/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/redis/versions.tf
+++ b/modules/redis/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/modules/secure_storage_connector/versions.tf
+++ b/modules/secure_storage_connector/versions.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_version = "~> 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.60"
-    }
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -69,8 +69,11 @@ variable "database_innodb_lru_scan_depth" {
 }
 
 variable "database_performance_insights_kms_key_arn" {
+  default     = null
   description = "Specifies an existing KMS key ARN to encrypt the performance insights data if performance_insights_enabled is was enabled out of band"
+  nullable    = true
   type        = string
+
 }
 
 ##########################################

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.60"
+      version = "~> 4.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
This upgrades the AWS provider to version 4. *This is a breaking change.* Before upgrading to this version, be sure you have upgraded to v1.16.10. 

Additionally, the variable `database_performance_insights_kms_key_arn` variable has been provided a default value of `null`. This results in the default KMS key being used for Performance Insight metrics.