### PR TITLE
feat: Update provider deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,29 +99,31 @@ resources that lack official modules.
 
 ### A note on updating EKS cluster version
 
-Users can update the EKS cluster version to the latest version offered by AWS. This can be done using the environment variable `eks_cluster_version`. Note that, cluster and nodegroup version updates can only be done in increments of one version at a time. For example, if your current cluster version is `1.21` and the latest version available is `1.24` - you'd need to:
+Users can update the EKS cluster version to the latest version offered by AWS. This can be done using the environment variable `eks_cluster_version`. Note that, cluster and nodegroup version updates can only be done in increments of one version at a time. For example, if your current cluster version is `1.21` and the latest version available is `1.25` - you'd need to:
 
-- Update `1.21` to `1.22`, run `terraform apply`,
-- then upgrade to `1.23`, run `tf apply` and
-- finally to `1.24`, run `tf apply`.
+1. update the cluster version in the app_eks module from `1.21` to `1.22`
+2.  run `terraform apply`
+3. update the cluster version to `1.23`
+4. run `terraform apply`
+5. update the cluster version to `1.24`
+...and so on and so forth.
 
-You will not be able to upgrade directly from `1.21` to `1.24`.
-
+Upgrades must be executed in step-wise fashion from one version to the next. You cannot skip versions when upgrading EKS.
 <!-- BEGIN_TF_DOCS -->
 
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.60 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.6 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.60 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.6 |
 
 ## Modules
 

--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -28,7 +28,7 @@ module "wandb_infra" {
   allowed_inbound_cidr      = var.allowed_inbound_cidr
   allowed_inbound_ipv6_cidr = ["::/0"]
 
-  eks_cluster_version            = "1.24"
+  eks_cluster_version            = "1.25"
   kubernetes_public_access       = true
   kubernetes_public_access_cidrs = ["0.0.0.0/0"]
 

--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -51,7 +51,7 @@ data "aws_eks_cluster_auth" "app_cluster" {
 
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.app_cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.app_cluster.certificate_authority.0.data)
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.app_cluster.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.app_cluster.token
 }
 

--- a/examples/public-dns-external/variables.tf
+++ b/examples/public-dns-external/variables.tf
@@ -26,12 +26,7 @@ variable "wandb_license" {
 variable "database_engine_version" {
   description = "Version for MySQL Auora"
   type        = string
-  default     = "8.0.mysql_aurora.3.01.0"
-
-  validation {
-    condition     = contains(["5.7", "8.0.mysql_aurora.3.01.0", "8.0.mysql_aurora.3.02.0"], var.database_engine_version)
-    error_message = "We only support MySQL: \"5.7\"; \"8.0.mysql_aurora.3.01.0\"; \"8.0.mysql_aurora.3.02.0\"."
-  }
+  default     = "8.0.mysql_aurora.3.02.2"
 }
 
 variable "database_instance_class" {

--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ module "app_lb" {
 resource "aws_autoscaling_attachment" "autoscaling_attachment" {
   for_each               = module.app_eks.autoscaling_group_names
   autoscaling_group_name = each.value
-  lb_target_group_arn   = module.app_lb.tg_app_arn
+  lb_target_group_arn    = module.app_lb.tg_app_arn
 }
 
 module "redis" {

--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ module "app_lb" {
 resource "aws_autoscaling_attachment" "autoscaling_attachment" {
   for_each               = module.app_eks.autoscaling_group_names
   autoscaling_group_name = each.value
-  alb_target_group_arn   = module.app_lb.tg_app_arn
+  lb_target_group_arn   = module.app_lb.tg_app_arn
 }
 
 module "redis" {

--- a/modules/app_eks/iam-policy-docs.tf
+++ b/modules/app_eks/iam-policy-docs.tf
@@ -6,7 +6,6 @@ data "aws_iam_policy_document" "node_cloudwatch" {
   }
 }
 
-
 data "aws_iam_policy_document" "node_IMDSv2" {
   statement {
     actions   = ["ec2:DescribeInstanceAttribute"]
@@ -15,7 +14,6 @@ data "aws_iam_policy_document" "node_IMDSv2" {
   }
 }
 
-// todo: refactor --> v1.16.3
 data "aws_iam_policy_document" "node_kms" {
   statement {
     actions = [
@@ -30,8 +28,6 @@ data "aws_iam_policy_document" "node_kms" {
   }
 }
 
-
-// todo: refactor --> v1.16.3
 data "aws_iam_policy_document" "node_sqs" {
   statement {
     actions   = ["sqs:*"]
@@ -39,7 +35,6 @@ data "aws_iam_policy_document" "node_sqs" {
     resources = var.bucket_sqs_queue_arn == "" || var.bucket_sqs_queue_arn == null ? ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${aws_iam_role.node.name}"] : [var.bucket_sqs_queue_arn]
   }
 }
-
 
 data "aws_iam_policy_document" "node_s3" {
   statement {

--- a/modules/app_eks/iam-policy-docs.tf
+++ b/modules/app_eks/iam-policy-docs.tf
@@ -1,6 +1,5 @@
 data "aws_iam_policy_document" "node_cloudwatch" {
   statement {
-    sid       = "bb2"
     actions   = ["cloudwatch:PutMetricData"]
     effect    = "Allow"
     resources = ["*"]
@@ -10,7 +9,6 @@ data "aws_iam_policy_document" "node_cloudwatch" {
 
 data "aws_iam_policy_document" "node_IMDSv2" {
   statement {
-    sid       = "cc3"
     actions   = ["ec2:DescribeInstanceAttribute"]
     effect    = "Allow"
     resources = ["*"]
@@ -20,7 +18,6 @@ data "aws_iam_policy_document" "node_IMDSv2" {
 // todo: refactor --> v1.16.3
 data "aws_iam_policy_document" "node_kms" {
   statement {
-    sid = "dd4"
     actions = [
       "kms:Encrypt",
       "kms:Decrypt",
@@ -37,7 +34,6 @@ data "aws_iam_policy_document" "node_kms" {
 // todo: refactor --> v1.16.3
 data "aws_iam_policy_document" "node_sqs" {
   statement {
-    sid       = "ee5"
     actions   = ["sqs:*"]
     effect    = "Allow"
     resources = var.bucket_sqs_queue_arn == "" || var.bucket_sqs_queue_arn == null ? ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${aws_iam_role.node.name}"] : [var.bucket_sqs_queue_arn]
@@ -47,7 +43,6 @@ data "aws_iam_policy_document" "node_sqs" {
 
 data "aws_iam_policy_document" "node_s3" {
   statement {
-    sid     = "ff6"
     actions = ["s3:*"]
     effect  = "Allow"
     resources = [

--- a/modules/app_eks/iam-roles.tf
+++ b/modules/app_eks/iam-roles.tf
@@ -2,8 +2,6 @@ resource "aws_iam_role" "node" {
   name               = "${var.namespace}-node"
   assume_role_policy = data.aws_iam_policy_document.node_assume.json
 
-  // todo: refactor --> v1.16.3
-  inline_policy {}
 }
 
 

--- a/modules/app_eks/variables.tf
+++ b/modules/app_eks/variables.tf
@@ -28,7 +28,7 @@ variable "cluster_endpoint_public_access_cidrs" {
 variable "cluster_version" {
   description = "Indicates AWS EKS cluster version"
   type        = string
-  default     = "1.21"
+  default     = "1.25"
 }
 
 variable "create_elasticache_security_group" {

--- a/modules/app_eks/variables.tf
+++ b/modules/app_eks/variables.tf
@@ -27,8 +27,9 @@ variable "cluster_endpoint_public_access_cidrs" {
 
 variable "cluster_version" {
   description = "Indicates AWS EKS cluster version"
+  nullable    = false
   type        = string
-  default     = "1.25"
+
 }
 
 variable "create_elasticache_security_group" {

--- a/modules/app_eks/variables.tf
+++ b/modules/app_eks/variables.tf
@@ -29,7 +29,6 @@ variable "cluster_version" {
   description = "Indicates AWS EKS cluster version"
   nullable    = false
   type        = string
-
 }
 
 variable "create_elasticache_security_group" {

--- a/modules/file_storage/main.tf
+++ b/modules/file_storage/main.tf
@@ -8,30 +8,12 @@ resource "aws_sqs_queue" "file_storage" {
 
   # Enable long-polling
   receive_wait_time_seconds = 10
-
   # kms_master_key_id = var.kms_key_arn
 }
 
+
 resource "aws_s3_bucket" "file_storage" {
   bucket = "${var.namespace}-file-storage-${random_pet.file_storage.id}"
-  acl    = "private"
-
-  cors_rule {
-    allowed_headers = ["*"]
-    allowed_methods = ["GET", "HEAD", "PUT"]
-    allowed_origins = ["*"]
-    expose_headers  = ["ETag"]
-    max_age_seconds = 3000
-  }
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = var.kms_key_arn
-        sse_algorithm     = var.sse_algorithm
-      }
-    }
-  }
 
   force_destroy = !var.deletion_protection
 
@@ -40,6 +22,18 @@ resource "aws_s3_bucket" "file_storage" {
   depends_on = [aws_sqs_queue.file_storage]
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "file_storage" {
+  bucket = aws_s3_bucket.file_storage.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = var.kms_key_arn
+      sse_algorithm     = var.sse_algorithm
+    }
+  }
+}
+
+
 resource "aws_s3_bucket_public_access_block" "file_storage" {
   bucket                  = aws_s3_bucket.file_storage.id
   block_public_acls       = true
@@ -47,6 +41,33 @@ resource "aws_s3_bucket_public_access_block" "file_storage" {
   restrict_public_buckets = true
   ignore_public_acls      = true
 }
+
+resource "aws_s3_bucket_ownership_controls" "file_storage" {
+  bucket = aws_s3_bucket.file_storage.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "file_storage" {
+  depends_on = [aws_s3_bucket_ownership_controls.file_storage]
+
+  bucket = aws_s3_bucket.file_storage.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_cors_configuration" "file_storage" {
+  bucket = aws_s3_bucket.file_storage.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "HEAD", "PUT"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}
+
 
 # Give the bucket permission to send messages onto the queue. Looks like we
 # overide this value.

--- a/modules/file_storage/main.tf
+++ b/modules/file_storage/main.tf
@@ -22,33 +22,6 @@ resource "aws_s3_bucket" "file_storage" {
   depends_on = [aws_sqs_queue.file_storage]
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "file_storage" {
-  bucket = aws_s3_bucket.file_storage.id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      kms_master_key_id = var.kms_key_arn
-      sse_algorithm     = var.sse_algorithm
-    }
-  }
-}
-
-
-resource "aws_s3_bucket_public_access_block" "file_storage" {
-  bucket                  = aws_s3_bucket.file_storage.id
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
-}
-
-resource "aws_s3_bucket_ownership_controls" "file_storage" {
-  bucket = aws_s3_bucket.file_storage.id
-  rule {
-    object_ownership = "BucketOwnerPreferred"
-  }
-}
-
 resource "aws_s3_bucket_acl" "file_storage" {
   depends_on = [aws_s3_bucket_ownership_controls.file_storage]
 
@@ -67,6 +40,34 @@ resource "aws_s3_bucket_cors_configuration" "file_storage" {
     max_age_seconds = 3000
   }
 }
+
+resource "aws_s3_bucket_ownership_controls" "file_storage" {
+  bucket = aws_s3_bucket.file_storage.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "file_storage" {
+  bucket                  = aws_s3_bucket.file_storage.id
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+  ignore_public_acls      = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "file_storage" {
+  bucket = aws_s3_bucket.file_storage.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = var.kms_key_arn
+      sse_algorithm     = var.sse_algorithm
+    }
+  }
+}
+
+
 
 
 # Give the bucket permission to send messages onto the queue. Looks like we

--- a/modules/file_storage/outputs.tf
+++ b/modules/file_storage/outputs.tf
@@ -6,6 +6,10 @@ output "bucket_arn" {
   value = aws_s3_bucket.file_storage.arn
 }
 
+output "bucket_id" {
+  value = aws_s3_bucket.file_storage.id
+}
+
 output "bucket_region" {
   value = aws_s3_bucket.file_storage.region
 }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -3,10 +3,10 @@ locals {
 }
 
 resource "aws_elasticache_replication_group" "default" {
-  replication_group_id          = "${var.namespace}-rep-group"
-  description = "${var.namespace}-rep-group"
-  num_cache_clusters         = 2
-  port                          = 6379
+  replication_group_id = "${var.namespace}-rep-group"
+  description          = "${var.namespace}-rep-group"
+  num_cache_clusters   = 2
+  port                 = 6379
 
   node_type            = var.node_type
   parameter_group_name = "default.redis6.x"

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -4,8 +4,8 @@ locals {
 
 resource "aws_elasticache_replication_group" "default" {
   replication_group_id          = "${var.namespace}-rep-group"
-  replication_group_description = "${var.namespace}-rep-group"
-  number_cache_clusters         = 2
+  description = "${var.namespace}-rep-group"
+  num_cache_clusters         = 2
   port                          = 6379
 
   node_type            = var.node_type

--- a/modules/secure_storage_connector/outputs.tf
+++ b/modules/secure_storage_connector/outputs.tf
@@ -2,6 +2,11 @@ output "bucket" {
   value = data.aws_s3_bucket.file_storage
 }
 
+output "bucket_id" {
+  value = data.aws_s3_bucket.file_storage.id
+}
+
 output "bucket_kms_key" {
   value = var.create_kms_key ? aws_kms_key.key[0] : null
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -233,7 +233,6 @@ variable "network_elasticache_subnet_cidrs" {
 # EKS Cluster                            #
 ##########################################
 variable "eks_cluster_version" {
-  default     = "1.25"
   description = "EKS cluster kubernetes version"
   nullable    = false
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -235,7 +235,7 @@ variable "network_elasticache_subnet_cidrs" {
 variable "eks_cluster_version" {
   type        = string
   description = "Indicates EKS cluster version"
-  default     = "1.21"
+  default     = "1.25"
 }
 
 variable "kubernetes_public_access" {

--- a/variables.tf
+++ b/variables.tf
@@ -233,9 +233,10 @@ variable "network_elasticache_subnet_cidrs" {
 # EKS Cluster                            #
 ##########################################
 variable "eks_cluster_version" {
-  type        = string
-  description = "Indicates EKS cluster version"
   default     = "1.25"
+  description = "EKS cluster kubernetes version"
+  nullable    = false
+  type        = string
 }
 
 variable "kubernetes_public_access" {


### PR DESCRIPTION
This update addresses: 

- deprecated attributes in the app_eks, redis, and secure_storage modules
-  inline s3 bucket policies have been replaced with corresponding resource attachments, namely `aws_s3_bucket_acl`, `aws_s3_bucket_cors_configuration`, `aws_s3_bucket_ownership_controls`, `aws_s3_bucket_public_access_block`, and `aws_s3_bucket_server_side_encryption_configuration`
- outdated README: the required AWS provider version has been upgraded; section on upgrading kubernetes version in EKS has been expanded
- the default version of EKS has been set to `1.25` in both the repository root and in the  `app_eks` module. neither sets a default or allows a `null` value, which relegates the definition of the kubernetes version used in the EKS cluster explicitly to the invocation of the module. (For example, look at the invocation of the `wandb_infra` module in `examples/public-dns-external/main.tf`.)
- the `inline_policies` attribute has been removed from the IAM role policies in the `app_eks` module. the effect here is that terraform will _not_ delete any in-line policies it finds attached to the role. this shouldn't be a problem, since we moved from inline policies to the resource-attachment style prior to the v2.0 release. Again, it's critical that upgrades to this version be executed serially to make sure that these changes are affected. if inline policies remain defined, there will be a confilct, and the result is that the policies defined in the `app_eks` module. 