### PR TITLE
feat: Add additional outputs to overall module

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,14 @@ Upgrades must be executed in step-wise fashion from one version to the next. You
 | <a name="output_cluster_node_role"></a> [cluster\_node\_role](#output\_cluster\_node\_role) | n/a |
 | <a name="output_database_connection_string"></a> [database\_connection\_string](#output\_database\_connection\_string) | n/a |
 | <a name="output_elasticache_connection_string"></a> [elasticache\_connection\_string](#output\_elasticache\_connection\_string) | n/a |
+| <a name="output_elasticache_security_group_id"></a> [elasticache\_security\_group\_id](#output\_elasticache\_security\_group\_id) | n/a |
+| <a name="output_elasticache_subnet_group_name"></a> [elasticache\_subnet\_group\_name](#output\_elasticache\_subnet\_group\_name) | n/a |
 | <a name="output_internal_app_port"></a> [internal\_app\_port](#output\_internal\_app\_port) | n/a |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | The Amazon Resource Name of the KMS key used to encrypt data at rest. |
 | <a name="output_network_id"></a> [network\_id](#output\_network\_id) | The identity of the VPC in which resources are deployed. |
 | <a name="output_network_private_subnets"></a> [network\_private\_subnets](#output\_network\_private\_subnets) | The identities of the private subnetworks deployed within the VPC. |
 | <a name="output_network_public_subnets"></a> [network\_public\_subnets](#output\_network\_public\_subnets) | The identities of the public subnetworks deployed within the VPC. |
 | <a name="output_url"></a> [url](#output\_url) | The URL to the W&B application |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc_id) | n/a |
 
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -217,6 +217,6 @@ Upgrades must be executed in step-wise fashion from one version to the next. You
 | <a name="output_network_private_subnets"></a> [network\_private\_subnets](#output\_network\_private\_subnets) | The identities of the private subnetworks deployed within the VPC. |
 | <a name="output_network_public_subnets"></a> [network\_public\_subnets](#output\_network\_public\_subnets) | The identities of the public subnetworks deployed within the VPC. |
 | <a name="output_url"></a> [url](#output\_url) | The URL to the W&B application |
-| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc_id) | n/a |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc_id) | The id of VPC where resources are created. |
 
 <!-- END_TF_DOCS -->

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -5,3 +5,7 @@ output "connection_string" {
 output "security_group_id" {
   value = aws_security_group.redis.id
 }
+
+output "subnet_group_name" {
+  value = aws_elasticache_replication_group.default.subnet_group_name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -56,3 +56,16 @@ output "internal_app_port" {
 output "elasticache_connection_string" {
   value = var.create_elasticache ? module.redis.0.connection_string : null
 }
+
+output "redis_security_group_id" {
+  value = module.redis[0].security_group_id
+}
+
+output "redis_subnet_group_name" {
+  value = module.redis[0].subnet_group_name
+}
+
+output "vpc_id" {
+  value = module.networking.vpc_id
+}
+


### PR DESCRIPTION
This PR adds the following outputs to the overall module:
- the Elasticache subnet group name
- Elasticache security group id
- the VPC id