### PR TITLE
chore: Delete cw log groups

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -111,7 +111,7 @@ module "aurora" {
   db_parameter_group_name             = aws_db_parameter_group.default.id
   db_subnet_group_name                = var.db_subnet_group_name
   deletion_protection                 = var.deletion_protection
-  enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
+  enabled_cloudwatch_logs_exports     = []
   engine                              = "aurora-mysql"
   engine_version                      = var.engine_version
   iam_database_authentication_enabled = false


### PR DESCRIPTION
This PR removes the Cloudwatch Log group definitions from the Aurora module. If the log groups are not deleted prior to the upgrade, the upgraded version of the Aurora module fails with the message, "Log group already exists." 