### PR TITLE
feat: Change default instance type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -279,7 +279,7 @@ variable "kubernetes_map_users" {
 variable "kubernetes_instance_types" {
   description = "EC2 Instance type for primary node group."
   type        = list(string)
-  default     = ["m4.large"]
+  default     = ["m5.large"]
 }
 
 variable "eks_policy_arns" {


### PR DESCRIPTION
This is a small change that updates the default instance type in the root module's variables to `m5.large`.