### PR TITLE
fix: Switch to gp3 volumes on EKS nodes

### DIFF
--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -54,19 +54,21 @@ module "eks" {
 
   node_groups = {
     primary = {
-      version                = var.cluster_version,
-      desired_capacity       = 2,
-      max_capacity           = 5,
-      min_capacity           = 2,
-      instance_types         = var.instance_types,
-      iam_role_arn           = aws_iam_role.node.arn,
+      # IMDsv2
       create_launch_template = local.encrypt_ebs_volume,
+      desired_capacity       = 2,
       disk_encrypted         = local.encrypt_ebs_volume,
       disk_kms_key_id        = var.kms_key_arn,
+      disk_type = "gp3"
+      enable_monitoring = true
       force_update_version   = local.encrypt_ebs_volume,
-      # IMDsv2
-      metadata_http_tokens                 = "required",
+      iam_role_arn           = aws_iam_role.node.arn,
+      instance_types         = var.instance_types,
+      max_capacity           = 5,
       metadata_http_put_response_hop_limit = 2
+      metadata_http_tokens                 = "required",
+      min_capacity           = 2,
+      version                = var.cluster_version,
     }
   }
 

--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -55,20 +55,20 @@ module "eks" {
   node_groups = {
     primary = {
       # IMDsv2
-      create_launch_template = local.encrypt_ebs_volume,
-      desired_capacity       = 2,
-      disk_encrypted         = local.encrypt_ebs_volume,
-      disk_kms_key_id        = var.kms_key_arn,
-      disk_type = "gp3"
-      enable_monitoring = true
-      force_update_version   = local.encrypt_ebs_volume,
-      iam_role_arn           = aws_iam_role.node.arn,
-      instance_types         = var.instance_types,
-      max_capacity           = 5,
+      create_launch_template               = local.encrypt_ebs_volume,
+      desired_capacity                     = 2,
+      disk_encrypted                       = local.encrypt_ebs_volume,
+      disk_kms_key_id                      = var.kms_key_arn,
+      disk_type                            = "gp3"
+      enable_monitoring                    = true
+      force_update_version                 = local.encrypt_ebs_volume,
+      iam_role_arn                         = aws_iam_role.node.arn,
+      instance_types                       = var.instance_types,
+      max_capacity                         = 5,
       metadata_http_put_response_hop_limit = 2
       metadata_http_tokens                 = "required",
-      min_capacity           = 2,
-      version                = var.cluster_version,
+      min_capacity                         = 2,
+      version                              = var.cluster_version,
     }
   }
 

--- a/modules/app_eks/variables.tf
+++ b/modules/app_eks/variables.tf
@@ -58,8 +58,8 @@ variable "kms_key_arn" {
 
 variable "instance_types" {
   description = "EC2 Instance type for primary node group."
+  nullable    = false
   type        = list(string)
-  default     = ["m4.large"]
 }
 
 variable "lb_security_group_inbound_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -279,7 +279,7 @@ variable "kubernetes_map_users" {
 variable "kubernetes_instance_types" {
   description = "EC2 Instance type for primary node group."
   type        = list(string)
-  default     = ["m7a.large"]
+  default     = ["m5.large"]
 }
 
 variable "eks_policy_arns" {

--- a/variables.tf
+++ b/variables.tf
@@ -279,7 +279,7 @@ variable "kubernetes_map_users" {
 variable "kubernetes_instance_types" {
   description = "EC2 Instance type for primary node group."
   type        = list(string)
-  default     = ["m5.large"]
+  default     = ["m7a.large"]
 }
 
 variable "eks_policy_arns" {

--- a/variables.tf
+++ b/variables.tf
@@ -279,7 +279,7 @@ variable "kubernetes_map_users" {
 variable "kubernetes_instance_types" {
   description = "EC2 Instance type for primary node group."
   type        = list(string)
-  default     = ["m7a.large"]
+  default     = ["m7a.large", "m6a.large"]
 }
 
 variable "eks_policy_arns" {

--- a/variables.tf
+++ b/variables.tf
@@ -279,7 +279,7 @@ variable "kubernetes_map_users" {
 variable "kubernetes_instance_types" {
   description = "EC2 Instance type for primary node group."
   type        = list(string)
-  default     = ["m7a.large", "m6a.large"]
+  default     = ["m7a.large"]
 }
 
 variable "eks_policy_arns" {


### PR DESCRIPTION
This PR updates the launch templates to use EBS `gp3` volume types.