### PR TITLE
feat(examples): Adds tf template for bring your own vpc and eks

### DIFF
--- a/examples/byo-vpc-eks/README.md
+++ b/examples/byo-vpc-eks/README.md
@@ -1,0 +1,45 @@
+# Deploy W&B required infrastructure to an existing VPC and existing EKS
+
+## About
+
+This exmaple is a minimal example of what is needed to deploy an instance of 
+Weights & Biases that uses an external DNS into an already existing VPC and EKS cluster.
+
+## Module Prerequites
+
+As with the main version of this module, this example assumes the following
+resources already exist:
+
+- Valid subdomain that uses Amazon Route 53 as the Dns services ([Learn more
+  here](<(https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingNewSubdomain.html)>)
+  1. Create a Route53 zone for `<subdomain>.<domain_name>`. When you want to use
+     Amazon Route 53 as the DNS service for a new subdomain without migrating
+     the parent domain, you start by creating a hosted zone for the subdomain.
+  2. Create a Namespace Record (NS) in your external DNS provide that points to
+     this Route53 zone. Update the DNS service for the parent domain by adding
+     NS records for the subdomain. This is known as delegating responsibility
+     for the subdomain to Route 53. For example, if the parent domain
+     example.com is hosted with another DNS service and you created the
+     subdomain test.example.com in Route 53, you must update the DNS service for
+     example.com with new NS records for test.example.com.
+- An existing VPC with public and private subnets.
+- An existing EKS cluster with a node group.
+- Valid W&B Local license (You get one at [here](https://deploy.wandb.ai))
+
+## A sample Terraform Variables Example looks like:
+Create a `terraform.tfvars` file in this directory before running this example
+```
+namespace                        = ""
+domain_name                      = ""
+zone_id                          = "Z01XXXXXXXXXXXXXX"
+wandb_license                    = "<license_key>"
+network_id                       = "vpc-xxxxxxxxxxxx"
+network_private_subnets          = ["subnet-aaaaaaaaaaaaaaaaa", "subnet-bbbbbbbbbbbbbbbbb", "subnet-ccccccccccccccccc"]
+network_public_subnets           = ["subnet-aaaaaaaaaaaaaaaaa", "subnet-bbbbbbbbbbbbbbbbb", "subnet-ccccccccccccccccc"]
+network_database_subnets         = ["subnet-aaaaaaaaaaaaaaaaa", "subnet-bbbbbbbbbbbbbbbbb", "subnet-ccccccccccccccccc"]
+network_cidr                     = "x.x.x.x/x"
+network_private_subnet_cidrs     = ["x.x.x.x/x", "x.x.x.x/x", "x.x.x.x/x"]
+network_public_subnet_cidrs      = ["x.x.x.x/x", "x.x.x.x/x", "x.x.x.x/x"]
+network_database_subnet_cidrs    = ["x.x.x.x/x", "x.x.x.x/x", "x.x.x.x/x"]
+eks_cluster_version              = "1.25"
+```

--- a/examples/byo-vpc-eks/README.md
+++ b/examples/byo-vpc-eks/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-This exmaple is a minimal example of what is needed to deploy an instance of 
+This example is a minimal example of what is needed to deploy an instance of 
 Weights & Biases that uses an external DNS into an already existing VPC and EKS cluster.
 
 ## Module Prerequites

--- a/examples/byo-vpc-eks/main.tf
+++ b/examples/byo-vpc-eks/main.tf
@@ -48,8 +48,6 @@ module "wandb_infra" {
   network_private_subnet_cidrs     = var.network_private_subnet_cidrs
   network_public_subnet_cidrs      = var.network_public_subnet_cidrs
   network_database_subnet_cidrs    = var.network_database_subnet_cidrs
-  # create_elasticache               = false
-  # network_elasticache_subnet_cidrs = 
 
   deletion_protection = false
 
@@ -101,7 +99,6 @@ module "wandb_app" {
   bucket_queue               = "internal://"
   bucket_kms_key_arn         = module.wandb_infra.kms_key_arn
   database_connection_string = "mysql://${module.wandb_infra.database_connection_string}"
-  # redis_connection_string    = "redis://${module.wandb_infra.elasticache_connection_string}?tls=true&ttlInSeconds=604800"
 
   wandb_image   = var.wandb_image
   wandb_version = var.wandb_version

--- a/examples/byo-vpc-eks/main.tf
+++ b/examples/byo-vpc-eks/main.tf
@@ -1,0 +1,120 @@
+terraform {
+  backend "s3" {
+    bucket = "<bucket-name>" #TODO: Replace with bucket name where you want to store the Terraform state
+    key    = "wandb-tf-state"
+    region = "<region-name>" #TODO: Replace if region is different
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.6"
+    }
+  }
+}
+
+provider "aws" {
+  region = "<region-name>" #TODO: Replace this with region name
+
+  default_tags {
+    tags = {
+      GithubRepo = "terraform-aws-wandb"
+      GithubOrg  = "wandb"
+      Environment = "Production"
+    }
+  }
+}
+
+module "wandb_infra" {
+  source  = "wandb/wandb/aws"
+  version = "3.0.0"
+
+  namespace     = var.namespace
+  public_access = true
+  external_dns  = true
+
+  create_vpc = false
+  
+  network_id   = var.vpc_id
+  network_cidr = var.vpc_cidr
+
+  network_private_subnets          = var.network_private_subnets
+  network_public_subnets           = var.network_public_subnets
+  network_database_subnets         = var.network_database_subnets 
+  network_private_subnet_cidrs     = var.network_private_subnet_cidrs
+  network_public_subnet_cidrs      = var.network_public_subnet_cidrs
+  network_database_subnet_cidrs    = var.network_database_subnet_cidrs
+  # create_elasticache               = false
+  # network_elasticache_subnet_cidrs = 
+
+  deletion_protection = false
+
+  database_instance_class      = var.database_instance_class
+  database_engine_version      = var.database_engine_version
+  database_snapshot_identifier = var.database_snapshot_identifier
+  database_sort_buffer_size    = var.database_sort_buffer_size
+
+  allowed_inbound_cidr      = var.allowed_inbound_cidr
+  allowed_inbound_ipv6_cidr = ["::/0"]
+
+  eks_cluster_version            = var.eks_cluster_version
+  kubernetes_public_access       = true
+  kubernetes_public_access_cidrs = ["0.0.0.0/0"]
+
+  create_elasticache = false
+
+  domain_name = var.domain_name
+  zone_id     = var.zone_id
+  subdomain   = var.subdomain
+
+  bucket_name        = var.bucket_name
+  bucket_kms_key_arn = var.bucket_kms_key_arn
+  use_internal_queue = true
+}
+
+data "aws_eks_cluster" "app_cluster" {
+  name = module.wandb_infra.cluster_id
+}
+
+data "aws_eks_cluster_auth" "app_cluster" {
+  name = module.wandb_infra.cluster_id
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.app_cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.app_cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.app_cluster.token
+}
+
+module "wandb_app" {
+  source = "github.com/wandb/terraform-kubernetes-wandb"
+
+  license = var.wandb_license
+
+  host                       = module.wandb_infra.url
+  bucket                     = "s3://${module.wandb_infra.bucket_name}"
+  bucket_aws_region          = module.wandb_infra.bucket_region
+  bucket_queue               = "internal://"
+  bucket_kms_key_arn         = module.wandb_infra.kms_key_arn
+  database_connection_string = "mysql://${module.wandb_infra.database_connection_string}"
+  # redis_connection_string    = "redis://${module.wandb_infra.elasticache_connection_string}?tls=true&ttlInSeconds=604800"
+
+  wandb_image   = var.wandb_image
+  wandb_version = var.wandb_version
+
+  service_port = module.wandb_infra.internal_app_port
+
+  depends_on = [module.wandb_infra]
+}
+
+output "bucket_name" {
+  value = module.wandb_infra.bucket_name
+}
+
+output "bucket_queue_name" {
+  value = module.wandb_infra.bucket_queue_name
+}

--- a/examples/byo-vpc-eks/variables.tf
+++ b/examples/byo-vpc-eks/variables.tf
@@ -1,0 +1,129 @@
+variable "namespace" {
+  type        = string
+  description = "Name prefix used for resources"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name used to access instance."
+}
+
+variable "zone_id" {
+  type        = string
+  description = "Id of Route53 zone"
+}
+
+variable "subdomain" {
+  type        = string
+  default     = null
+  description = "Subdomain for accessing the Weights & Biases UI."
+}
+
+variable "wandb_license" {
+  type = string
+}
+
+variable "database_engine_version" {
+  description = "Version for MySQL Auora"
+  type        = string
+  default     = "5.7.mysql_aurora.2.11.2"
+}
+
+variable "database_instance_class" {
+  description = "Instance type to use by database master instance."
+  type        = string
+  default     = "db.r5.4xlarge"
+}
+
+variable "database_snapshot_identifier" {
+  description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot"
+  type        = string
+  default     = null
+}
+
+variable "database_sort_buffer_size" {
+  description = "Specifies the sort_buffer_size value to set for the database"
+  type        = number
+  default     = 262144
+}
+
+variable "wandb_version" {
+  description = "The version of Weights & Biases local to deploy."
+  type        = string
+  default     = "latest"
+}
+
+variable "wandb_image" {
+  description = "Docker repository of to pull the wandb image from."
+  type        = string
+  default     = "wandb/local"
+}
+
+variable "bucket_name" {
+  type    = string
+  default = ""
+}
+
+variable "bucket_kms_key_arn" {
+  type        = string
+  description = "The Amazon Resource Name of the KMS key with which S3 storage bucket objects will be encrypted."
+  default     = ""
+}
+
+
+variable "allowed_inbound_cidr" {
+  default  = ["0.0.0.0/0"]
+  nullable = false
+  type     = list(string)
+}
+
+
+variable "allowed_inbound_ipv6_cidr" {
+  default  = ["::/0"]
+  nullable = false
+  type     = list(string)
+}
+
+variable "vpc_id" {
+    type = string
+    description = "VPC network ID"
+}
+variable vpc_cidr {
+    type = string
+    description = "VPC network CIDR"
+}   
+
+variable network_private_subnets {
+    type = list[string]
+    description = "Subnet IDs"
+}
+
+variable network_public_subnets {
+    type = list[string]
+    description = "Subnet IDs"
+}
+
+variable network_database_subnets {
+    type = list[string]
+    description = "Subnet IDs"
+}
+
+variable network_private_subnet_cidrs {
+    type = list[string]
+    description = "Subnet CIDRs"
+}
+
+variable network_public_subnet_cidrs {
+    type = list[string]
+    description = "Subnet CIDRs"
+}
+
+variable network_database_subnet_cidrs {
+    type = list[string]
+    description = "Subnet CIDRs"
+}
+
+eks_cluster_version {
+    type = string
+    description = "EKS cluster version"
+}

--- a/examples/byo-vpc-eks/variables.tf
+++ b/examples/byo-vpc-eks/variables.tf
@@ -123,7 +123,7 @@ variable network_database_subnet_cidrs {
     description = "Subnet CIDRs"
 }
 
-eks_cluster_version {
+variable eks_cluster_version {
     type = string
     description = "EKS cluster version"
 }


### PR DESCRIPTION
A few of customers in the past have requested to modify our terraform to allow provisioning resources into existing VPC and EKS clusters. This template helps with setting it up.

For context, customer who have asked for this in the past:
- DoorDash Labs
- Apple
- DIU