### PR TITLE
feat: Remove vpc-cni EKS add-on in app_eks/main.tf

### DIFF
--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -15,11 +15,15 @@ resource "aws_eks_addon" "eks" {
   ]
 }
 
-resource "aws_eks_addon" "vpc_cni" {
-  cluster_name = var.namespace
-  addon_name   = "vpc-cni"
-  depends_on   = [module.eks]
-}
+# removed due to conflict with 
+# AWS Load Balancer Controller
+# being installed with Helm.
+# See: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.6/
+#resource "aws_eks_addon" "vpc_cni" {
+#  cluster_name = var.namespace
+#  addon_name   = "vpc-cni"
+#  depends_on   = [module.eks]
+#}
 
 locals {
   managed_policy_arns = concat([


### PR DESCRIPTION
This removes the EKS addon defined in the terraform in favor of using the Helm chart.