### PR TITLE
fix: EFS index vs subnet for_each

### DIFF
--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region  = "us-west-2"
+  region = "us-west-2"
 
   default_tags {
     tags = {
@@ -36,7 +36,7 @@ module "wandb_infra" {
   zone_id     = var.zone_id
   subdomain   = var.subdomain
 
-  # license = var.wandb_license
+  license = var.wandb_license
 
   bucket_name        = var.bucket_name
   bucket_kms_key_arn = var.bucket_kms_key_arn

--- a/modules/app_eks/efs.tf
+++ b/modules/app_eks/efs.tf
@@ -34,7 +34,8 @@ resource "aws_security_group_rule" "nfs_ingress" {
 }
 
 resource "aws_efs_mount_target" "storage_class" {
-  for_each        = { for subnet in var.network_private_subnets : subnet => subnet }
+  for_each = { for index, subnet in var.network_private_subnets : index => subnet }
+
   file_system_id  = aws_efs_file_system.storage_class.id
   subnet_id       = each.value
   security_groups = [aws_security_group.storage_class_nfs.id]


### PR DESCRIPTION
This PR fixes the EFS logic when subnets don't already exist. 