### PR TITLE
feat: PrivateLink support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,15 +115,15 @@ Upgrades must be executed in step-wise fashion from one version to the next. You
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.23 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.6 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 
@@ -136,7 +136,9 @@ Upgrades must be executed in step-wise fashion from one version to the next. You
 | <a name="module_file_storage"></a> [file\_storage](#module\_file\_storage) | ./modules/file_storage | n/a |
 | <a name="module_kms"></a> [kms](#module\_kms) | ./modules/kms | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
+| <a name="module_private_link"></a> [private\_link](#module\_private\_link) | ./modules/private_link | n/a |
 | <a name="module_redis"></a> [redis](#module\_redis) | ./modules/redis | n/a |
+| <a name="module_wandb"></a> [wandb](#module\_wandb) | wandb/wandb/helm | 1.2.0 |
 
 ## Resources
 
@@ -157,31 +159,35 @@ Upgrades must be executed in step-wise fashion from one version to the next. You
 | <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | ######################################### External Bucket                        # ######################################### Most users will not need these settings. They are ment for users who want a bucket and sqs that are in a different account. | `bool` | `true` | no |
 | <a name="input_create_elasticache"></a> [create\_elasticache](#input\_create\_elasticache) | Boolean indicating whether to provision an elasticache instance (true) or not (false). | `bool` | `true` | no |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Boolean indicating whether to deploy a VPC (true) or not (false). | `bool` | `true` | no |
+| <a name="input_custom_domain_filter"></a> [custom\_domain\_filter](#input\_custom\_domain\_filter) | A custom domain filter to be used by external-dns instead of the default FQDN. If not set, the local FQDN is used. | `string` | `null` | no |
 | <a name="input_database_binlog_format"></a> [database\_binlog\_format](#input\_database\_binlog\_format) | Specifies the binlog\_format value to set for the database | `string` | `"ROW"` | no |
 | <a name="input_database_engine_version"></a> [database\_engine\_version](#input\_database\_engine\_version) | Version for MySQL Auora | `string` | `"8.0.mysql_aurora.3.03.0"` | no |
 | <a name="input_database_innodb_lru_scan_depth"></a> [database\_innodb\_lru\_scan\_depth](#input\_database\_innodb\_lru\_scan\_depth) | Specifies the innodb\_lru\_scan\_depth value to set for the database | `number` | `128` | no |
 | <a name="input_database_instance_class"></a> [database\_instance\_class](#input\_database\_instance\_class) | Instance type to use by database master instance. | `string` | `"db.r5.large"` | no |
 | <a name="input_database_master_username"></a> [database\_master\_username](#input\_database\_master\_username) | Specifies the master\_username value to set for the database | `string` | `"wandb"` | no |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Specifies the name of the database | `string` | `"wandb_local"` | no |
-| <a name="input_database_performance_insights_kms_key_arn"></a> [database\_performance\_insights\_kms\_key\_arn](#input\_database\_performance\_insights\_kms\_key\_arn) | Specifies an existing KMS key ARN to encrypt the performance insights data if performance\_insights\_enabled is was enabled out of band | `string` | n/a | yes |
+| <a name="input_database_performance_insights_kms_key_arn"></a> [database\_performance\_insights\_kms\_key\_arn](#input\_database\_performance\_insights\_kms\_key\_arn) | Specifies an existing KMS key ARN to encrypt the performance insights data if performance\_insights\_enabled is was enabled out of band | `string` | `null` | no |
 | <a name="input_database_snapshot_identifier"></a> [database\_snapshot\_identifier](#input\_database\_snapshot\_identifier) | Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot | `string` | `null` | no |
 | <a name="input_database_sort_buffer_size"></a> [database\_sort\_buffer\_size](#input\_database\_sort\_buffer\_size) | Specifies the sort\_buffer\_size value to set for the database | `number` | `67108864` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | If the instance should have deletion protection enabled. The database / S3 can't be deleted when this value is set to `true`. | `bool` | `true` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain for accessing the Weights & Biases UI. | `string` | n/a | yes |
-| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | Indicates EKS cluster version | `string` | `"1.21"` | no |
+| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | EKS cluster kubernetes version | `string` | n/a | yes |
 | <a name="input_eks_policy_arns"></a> [eks\_policy\_arns](#input\_eks\_policy\_arns) | Additional IAM policy to apply to the EKS cluster | `list(string)` | `[]` | no |
 | <a name="input_elasticache_node_type"></a> [elasticache\_node\_type](#input\_elasticache\_node\_type) | The type of the redis cache node to deploy | `string` | `"cache.t2.medium"` | no |
+| <a name="input_enable_dummy_dns"></a> [enable\_dummy\_dns](#input\_enable\_dummy\_dns) | Boolean indicating whether or not to enable dummy DNS for the old alb | `bool` | `false` | no |
+| <a name="input_enable_operator_alb"></a> [enable\_operator\_alb](#input\_enable\_operator\_alb) | Boolean indicating whether to use operatore ALB (true) or not (false). | `bool` | `false` | no |
 | <a name="input_external_dns"></a> [external\_dns](#input\_external\_dns) | Using external DNS. A `subdomain` must also be specified if this value is true. | `bool` | `false` | no |
 | <a name="input_extra_fqdn"></a> [extra\_fqdn](#input\_extra\_fqdn) | n/a | `list(string)` | `[]` | no |
 | <a name="input_kms_key_alias"></a> [kms\_key\_alias](#input\_kms\_key\_alias) | KMS key alias for AWS KMS Customer managed key. | `string` | `null` | no |
 | <a name="input_kms_key_deletion_window"></a> [kms\_key\_deletion\_window](#input\_kms\_key\_deletion\_window) | Duration in days to destroy the key after it is deleted. Must be between 7 and 30 days. | `number` | `7` | no |
 | <a name="input_kms_key_policy"></a> [kms\_key\_policy](#input\_kms\_key\_policy) | The policy that will define the permissions for the kms key. | `string` | `""` | no |
-| <a name="input_kubernetes_instance_types"></a> [kubernetes\_instance\_types](#input\_kubernetes\_instance\_types) | EC2 Instance type for primary node group. | `list(string)` | <pre>[<br>  "m4.large"<br>]</pre> | no |
+| <a name="input_kubernetes_instance_types"></a> [kubernetes\_instance\_types](#input\_kubernetes\_instance\_types) | EC2 Instance type for primary node group. | `list(string)` | <pre>[<br>  "m5.large"<br>]</pre> | no |
 | <a name="input_kubernetes_map_accounts"></a> [kubernetes\_map\_accounts](#input\_kubernetes\_map\_accounts) | Additional AWS account numbers to add to the aws-auth configmap. | `list(string)` | `[]` | no |
 | <a name="input_kubernetes_map_roles"></a> [kubernetes\_map\_roles](#input\_kubernetes\_map\_roles) | Additional IAM roles to add to the aws-auth configmap. | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_kubernetes_map_users"></a> [kubernetes\_map\_users](#input\_kubernetes\_map\_users) | Additional IAM users to add to the aws-auth configmap. | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_kubernetes_public_access"></a> [kubernetes\_public\_access](#input\_kubernetes\_public\_access) | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | `bool` | `false` | no |
 | <a name="input_kubernetes_public_access_cidrs"></a> [kubernetes\_public\_access\_cidrs](#input\_kubernetes\_public\_access\_cidrs) | List of CIDR blocks which can access the Amazon EKS public API server endpoint. | `list(string)` | `[]` | no |
+| <a name="input_license"></a> [license](#input\_license) | Weights & Biases license key. | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | String used for prefix resources. | `string` | n/a | yes |
 | <a name="input_network_cidr"></a> [network\_cidr](#input\_network\_cidr) | CIDR block for VPC. | `string` | `"10.10.0.0/16"` | no |
 | <a name="input_network_database_subnet_cidrs"></a> [network\_database\_subnet\_cidrs](#input\_network\_database\_subnet\_cidrs) | List of private subnet CIDR ranges to create in VPC. | `list(string)` | <pre>[<br>  "10.10.20.0/24",<br>  "10.10.21.0/24"<br>]</pre> | no |
@@ -192,6 +198,8 @@ Upgrades must be executed in step-wise fashion from one version to the next. You
 | <a name="input_network_private_subnets"></a> [network\_private\_subnets](#input\_network\_private\_subnets) | A list of the identities of the private subnetworks in which resources will be deployed. | `list(string)` | `[]` | no |
 | <a name="input_network_public_subnet_cidrs"></a> [network\_public\_subnet\_cidrs](#input\_network\_public\_subnet\_cidrs) | List of private subnet CIDR ranges to create in VPC. | `list(string)` | <pre>[<br>  "10.10.0.0/24",<br>  "10.10.1.0/24"<br>]</pre> | no |
 | <a name="input_network_public_subnets"></a> [network\_public\_subnets](#input\_network\_public\_subnets) | A list of the identities of the public subnetworks in which resources will be deployed. | `list(string)` | `[]` | no |
+| <a name="input_other_wandb_env"></a> [other\_wandb\_env](#input\_other\_wandb\_env) | Extra environment variables for W&B | `map(any)` | `{}` | no |
+| <a name="input_private_link_allowed_account_ids"></a> [private\_link\_allowed\_account\_ids](#input\_private\_link\_allowed\_account\_ids) | List of AWS account IDs allowed to access the VPC Endpoint Service | `list(string)` | `[]` | no |
 | <a name="input_public_access"></a> [public\_access](#input\_public\_access) | Is this instance accessable a public domain. | `bool` | `false` | no |
 | <a name="input_ssl_policy"></a> [ssl\_policy](#input\_ssl\_policy) | SSL policy to use on ALB listener | `string` | `"ELBSecurityPolicy-FS-1-2-Res-2020-10"` | no |
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain for accessing the Weights & Biases UI. Default creates record at Route53 Route. | `string` | `null` | no |
@@ -208,6 +216,8 @@ Upgrades must be executed in step-wise fashion from one version to the next. You
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | n/a |
 | <a name="output_cluster_node_role"></a> [cluster\_node\_role](#output\_cluster\_node\_role) | n/a |
 | <a name="output_database_connection_string"></a> [database\_connection\_string](#output\_database\_connection\_string) | n/a |
+| <a name="output_database_password"></a> [database\_password](#output\_database\_password) | n/a |
+| <a name="output_database_username"></a> [database\_username](#output\_database\_username) | n/a |
 | <a name="output_elasticache_connection_string"></a> [elasticache\_connection\_string](#output\_elasticache\_connection\_string) | n/a |
 | <a name="output_internal_app_port"></a> [internal\_app\_port](#output\_internal\_app\_port) | n/a |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | The Amazon Resource Name of the KMS key used to encrypt data at rest. |

--- a/main.tf
+++ b/main.tf
@@ -165,6 +165,24 @@ module "app_lb" {
   network_public_subnets  = local.network_public_subnets
 }
 
+module "private_link" {
+  count  = length(var.private_link_allowed_account_ids) > 0 ? 1 : 0
+  source = "./modules/private_link"
+
+  namespace               = var.namespace
+  allowed_account_ids     = var.private_link_allowed_account_ids
+  deletion_protection     = var.deletion_protection
+  network_private_subnets = local.network_private_subnets
+  alb_name                = local.lb_name_truncated
+  vpc_id                  = local.network_id
+  cluster_id              = module.app_eks.cluster_id
+  acm_certificate_arn     = local.acm_certificate_arn
+
+  depends_on = [
+    module.wandb
+  ]
+}
+
 resource "aws_autoscaling_attachment" "autoscaling_attachment" {
   for_each               = module.app_eks.autoscaling_group_names
   autoscaling_group_name = each.value

--- a/main.tf
+++ b/main.tf
@@ -249,6 +249,8 @@ module "wandb" {
       ingress = {
         class = "alb"
 
+        additionalHosts = concat(var.extra_fqdn, length(var.private_link_allowed_account_ids) > 0 ? [""] : [])
+
         annotations = {
           "alb.ingress.kubernetes.io/load-balancer-name"             = local.lb_name_truncated
           "alb.ingress.kubernetes.io/inbound-cidrs"                  = <<-EOF

--- a/main.tf
+++ b/main.tf
@@ -175,8 +175,6 @@ module "private_link" {
   network_private_subnets = local.network_private_subnets
   alb_name                = local.lb_name_truncated
   vpc_id                  = local.network_id
-  cluster_id              = module.app_eks.cluster_id
-  acm_certificate_arn     = local.acm_certificate_arn
 
   depends_on = [
     module.wandb

--- a/modules/private_link/main.tf
+++ b/modules/private_link/main.tf
@@ -35,7 +35,7 @@ data "aws_lb" "alb" {
 }
 
 resource "aws_lb_target_group_attachment" "nlb_to_alb" {
-  target_group_arn = aws_lb_target_group.nlb_tg.arn
+  target_group_arn = aws_lb_target_group.nlb.arn
   target_id        = data.aws_lb.alb.arn
 }
 
@@ -52,6 +52,6 @@ resource "aws_lb_listener" "nlb" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.nlb_tg.arn
+    target_group_arn = aws_lb_target_group.nlb.arn
   }
 }

--- a/modules/private_link/main.tf
+++ b/modules/private_link/main.tf
@@ -1,0 +1,57 @@
+locals {
+  max_lb_name_length = 32 - length("-nlb")
+  lb_name_truncated  = "${substr(var.namespace, 0, local.max_lb_name_length)}-nlb"
+}
+
+resource "aws_lb" "nlb" {
+  name                       = local.lb_name_truncated
+  internal                   = true
+  load_balancer_type         = "network"
+  subnets                    = var.network_private_subnets
+  enable_deletion_protection = var.deletion_protection
+}
+
+resource "aws_lb_target_group" "nlb_tg" {
+  name        = "${var.namespace}-nlb-tg"
+  protocol    = "TCP"
+  target_type = "alb"
+  port        = 443
+  vpc_id      = var.vpc_id
+
+  health_check {
+    protocol            = "HTTPS"
+    path                = "/healthz"
+    matcher             = "200-399"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 10
+    port                = "traffic-port"
+  }
+}
+
+data "aws_lb" "alb" {
+  name = var.alb_name
+}
+
+resource "aws_lb_target_group_attachment" "nlb_to_alb" {
+  target_group_arn = aws_lb_target_group.nlb_tg.arn
+  target_id        = data.aws_lb.alb.arn
+}
+
+resource "aws_vpc_endpoint_service" "private_link" {
+  acceptance_required        = false
+  network_load_balancer_arns = [aws_lb.nlb.arn]
+  allowed_principals         = [for id in var.allowed_account_ids : "arn:aws:iam::${id}:root"]
+}
+
+resource "aws_lb_listener" "nlb" {
+  load_balancer_arn = aws_lb.nlb.arn
+  protocol          = "TCP"
+  port              = 443
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.nlb_tg.arn
+  }
+}

--- a/modules/private_link/main.tf
+++ b/modules/private_link/main.tf
@@ -11,7 +11,7 @@ resource "aws_lb" "nlb" {
   enable_deletion_protection = var.deletion_protection
 }
 
-resource "aws_lb_target_group" "nlb_tg" {
+resource "aws_lb_target_group" "nlb" {
   name        = "${var.namespace}-nlb-tg"
   protocol    = "TCP"
   target_type = "alb"

--- a/modules/private_link/variables.tf
+++ b/modules/private_link/variables.tf
@@ -1,0 +1,47 @@
+variable "namespace" {
+  description = "Namespace for naming resources"
+  type        = string
+}
+
+variable "allowed_account_ids" {
+  description = "List of AWS account IDs allowed to access the VPC Endpoint Service"
+  type        = list(string)
+}
+
+variable "network_private_subnets" {
+  description = "List of private subnets for the VPC"
+  type        = list(string)
+}
+
+variable "deletion_protection" {
+  description = "If the instance should have deletion protection enabled. The database / S3 can't be deleted when this value is set to `true`."
+  type        = bool
+}
+
+variable "alb_name" {
+  description = "Name of the ALB to forward NLB traffic to"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC to create the VPC Endpoint Service in"
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "The EKS cluster ID needed to get the tags for the target group"
+  type        = string
+}
+
+variable "ssl_policy" {
+  type        = string
+  default     = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
+  description = "(Optional) SSL policy to use on ALB listener"
+}
+
+variable "acm_certificate_arn" {
+  type        = string
+  description = "(Optional) The ARN of an existing ACM certificate."
+  default     = null
+}
+

--- a/modules/private_link/variables.tf
+++ b/modules/private_link/variables.tf
@@ -27,21 +27,3 @@ variable "vpc_id" {
   description = "ID of the VPC to create the VPC Endpoint Service in"
   type        = string
 }
-
-variable "cluster_id" {
-  description = "The EKS cluster ID needed to get the tags for the target group"
-  type        = string
-}
-
-variable "ssl_policy" {
-  type        = string
-  default     = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
-  description = "(Optional) SSL policy to use on ALB listener"
-}
-
-variable "acm_certificate_arn" {
-  type        = string
-  description = "(Optional) The ARN of an existing ACM certificate."
-  default     = null
-}
-

--- a/variables.tf
+++ b/variables.tf
@@ -247,6 +247,11 @@ variable "network_elasticache_subnet_cidrs" {
   default     = ["10.10.30.0/24", "10.10.31.0/24"]
 }
 
+variable "private_link_allowed_account_ids" {
+  description = "List of AWS account IDs allowed to access the VPC Endpoint Service"
+  type        = list(string)
+  default     = []
+}
 
 ##########################################
 # EKS Cluster                            #


### PR DESCRIPTION
This pull request introduces a p`rivate_link module` to enable to automatic setting up AWS PrivateLink. 

The key variable is `private_link_allowed_account_ids`, which triggers the module only when a list of allowed AWS account IDs is provided. 

Other crucial variables include `namespace` for resource naming (and the limit of LB's names), `network_private_subnets` for specifying VPC private subnets and `deletion_protection` for enabling deletion protection.