### PR TITLE
fix: use an empty additional host

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -233,6 +233,8 @@ module "wandb" {
       ingress = {
         class = "alb"
 
+        additionalHosts = [""]
+
         annotations = {
           "alb.ingress.kubernetes.io/load-balancer-name"             = local.lb_name_truncated
           "alb.ingress.kubernetes.io/inbound-cidrs"                  = <<-EOF


### PR DESCRIPTION
We need to set an empty additional host to support private link. This is because it may not be the same as the fqdn.