### PR TITLE
chore(backend): Add 'defaultTags' for AWS LB controller

### DIFF
--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -47,6 +47,8 @@ module "wandb_infra" {
   system_reserved_memory_megabytes    = var.system_reserved_memory_megabytes
   system_reserved_ephemeral_megabytes = var.system_reserved_ephemeral_megabytes
   system_reserved_pid                 = var.system_reserved_pid
+
+  aws_loadbalancer_controller_tags = var.aws_loadbalancer_controller_tags
 }
 
 data "aws_eks_cluster" "app_cluster" {

--- a/examples/public-dns-external/variables.tf
+++ b/examples/public-dns-external/variables.tf
@@ -120,3 +120,9 @@ variable "system_reserved_pid" {
   type        = number
   default     = -1
 }
+
+variable "aws_loadbalancer_controller_tags" {
+  description = "(Optional) A map of AWS tags to apply to all resources managed by the load balancer controller"
+  type        = map(string)
+  default     = {}
+}

--- a/main.tf
+++ b/main.tf
@@ -148,6 +148,8 @@ module "app_eks" {
   system_reserved_memory_megabytes    = var.system_reserved_memory_megabytes
   system_reserved_ephemeral_megabytes = var.system_reserved_ephemeral_megabytes
   system_reserved_pid                 = var.system_reserved_pid
+
+  aws_loadbalancer_controller_tags = var.aws_loadbalancer_controller_tags
 }
 
 module "app_lb" {

--- a/modules/app_eks/iam-roles.tf
+++ b/modules/app_eks/iam-roles.tf
@@ -1,7 +1,4 @@
 resource "aws_iam_role" "node" {
   name               = "${var.namespace}-node"
   assume_role_policy = data.aws_iam_policy_document.node_assume.json
-
 }
-
-

--- a/modules/app_eks/lb_controller/controller.tf
+++ b/modules/app_eks/lb_controller/controller.tf
@@ -1,3 +1,10 @@
+locals {
+  defaultTags = jsonencode(merge({
+    "namespace" : var.namespace
+    },
+  var.aws_loadbalancer_controller_tags))
+}
+
 resource "helm_release" "aws_load_balancer_controller" {
   name       = "aws-load-balancer-controller"
   repository = "https://aws.github.io/eks-charts"
@@ -19,6 +26,13 @@ resource "helm_release" "aws_load_balancer_controller" {
     name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
     value = aws_iam_role.default.arn
   }
+
+  values = [
+    <<EOT
+defaultTags:
+  ${local.defaultTags}
+EOT
+  ]
 
   depends_on = [aws_iam_role_policy_attachment.default]
 }

--- a/modules/app_eks/lb_controller/variables.tf
+++ b/modules/app_eks/lb_controller/variables.tf
@@ -8,3 +8,7 @@ variable "oidc_provider" {
     url = string
   })
 }
+
+variable "aws_loadbalancer_controller_tags" {
+  type = map(string)
+}

--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -150,8 +150,9 @@ resource "aws_iam_openid_connect_provider" "eks" {
 module "lb_controller" {
   source = "./lb_controller"
 
-  namespace     = var.namespace
-  oidc_provider = aws_iam_openid_connect_provider.eks
+  namespace                        = var.namespace
+  oidc_provider                    = aws_iam_openid_connect_provider.eks
+  aws_loadbalancer_controller_tags = var.aws_loadbalancer_controller_tags
 
   depends_on = [module.eks]
 }

--- a/modules/app_eks/variables.tf
+++ b/modules/app_eks/variables.tf
@@ -145,3 +145,9 @@ variable "system_reserved_pid" {
   type        = number
   default     = -1
 }
+
+variable "aws_loadbalancer_controller_tags" {
+  description = "(Optional) A map of AWS tags to apply to all resources managed by the load balancer controller"
+  type        = map(string)
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -367,6 +367,12 @@ variable "system_reserved_pid" {
   default     = 500
 }
 
+variable "aws_loadbalancer_controller_tags" {
+  description = "(Optional) A map of AWS tags to apply to all resources managed by the load balancer controller"
+  type        = map(string)
+  default     = {}
+}
+
 ##########################################
 # External Bucket                        #
 ##########################################


### PR DESCRIPTION
Add `defaultTags` to the AWS LB controller which defaults to just adding `namespace`
Add `aws_loadbalancer_controller_tags` variable to allow for additional default tags.

Tested with `nigel-test-perceive` cluster, ALBs get proper tags in the default and extra scenarios.