### PR TITLE
fix(deployer): Update external_dns interval

### DIFF
--- a/modules/app_eks/external_dns/external_dns.tf
+++ b/modules/app_eks/external_dns/external_dns.tf
@@ -31,6 +31,11 @@ resource "helm_release" "external_dns" {
   }
 
   set {
+    name  = "interval"
+    value = "3m"
+  }
+
+  set {
     name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
     value = aws_iam_role.default.arn
   }


### PR DESCRIPTION
Default is "1m", but we are hitting API rate limiting.