### PR TITLE
feat: Set default EKS to 1.26; install vpc-cni add-on

### DIFF
--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -28,7 +28,7 @@ module "wandb_infra" {
   allowed_inbound_cidr      = var.allowed_inbound_cidr
   allowed_inbound_ipv6_cidr = ["::/0"]
 
-  eks_cluster_version            = "1.25"
+  eks_cluster_version            = "1.26"
   kubernetes_public_access       = true
   kubernetes_public_access_cidrs = ["0.0.0.0/0"]
 

--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -43,7 +43,7 @@ resource "aws_eks_addon" "aws_efs_csi_driver" {
 
 resource "aws_eks_addon" "aws_ebs_csi_driver" {
   depends_on = [
-    aws_eks_addon.vpc-cni
+    aws_eks_addon.vpc_cni
   ]
   cluster_name                = var.namespace
   addon_name                  = "aws-ebs-csi-driver"

--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -63,7 +63,7 @@ resource "aws_eks_addon" "coredns" {
 
 resource "aws_eks_addon" "kube_proxy" {
   depends_on = [
-    aws_eks_addon.vpc-cni
+    aws_eks_addon.vpc_cni
   ]
   cluster_name                = var.namespace
   addon_name                  = "kube-proxy"

--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -1,4 +1,5 @@
 
+### IAM policy and role for vpc-cni
 data "aws_iam_policy_document" "oidc_assume_role" {
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]
@@ -27,6 +28,11 @@ resource "aws_iam_role" "oidc" {
   assume_role_policy = data.aws_iam_policy_document.oidc_assume_role.json
 }
 
+
+
+
+
+### add-ons
 resource "aws_eks_addon" "aws-efs-csi-driver" {
    depends_on = [
      aws_eks_addon.vpc-cni

--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -30,10 +30,8 @@ resource "aws_iam_role" "oidc" {
 
 
 
-
-
 ### add-ons
-resource "aws_eks_addon" "aws-efs-csi-driver" {
+resource "aws_eks_addon" "aws_efs_csi_driver" {
    depends_on = [
      aws_eks_addon.vpc-cni
    ]
@@ -43,7 +41,7 @@ resource "aws_eks_addon" "aws-efs-csi-driver" {
    resolve_conflicts          = "OVERWRITE"
  }
 
-resource "aws_eks_addon" "aws-ebs-csi-driver" {
+resource "aws_eks_addon" "aws_ebs_csi_driver" {
   depends_on = [
     aws_eks_addon.vpc-cni
   ]
@@ -63,7 +61,7 @@ resource "aws_eks_addon" "coredns" {
   resolve_conflicts           = "OVERWRITE"
 }
 
-resource "aws_eks_addon" "kube-proxy" {
+resource "aws_eks_addon" "kube_proxy" {
   depends_on = [
     aws_eks_addon.vpc-cni
   ]
@@ -73,7 +71,7 @@ resource "aws_eks_addon" "kube-proxy" {
   resolve_conflicts           = "OVERWRITE"
 }
 
-resource "aws_eks_addon" "vpc-cni" {
+resource "aws_eks_addon" "vpc_cni" {
   cluster_name                = var.namespace
   addon_name                  = "vpc-cni"
   addon_version               = "v1.18.0-eksbuild.1"

--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "oidc_assume_role" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "eks-oidc" {
+resource "aws_iam_role_policy_attachment" "eks_oidc" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
   role       = aws_iam_role.oidc.name
 }

--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -27,15 +27,15 @@ resource "aws_iam_role" "oidc" {
   assume_role_policy = data.aws_iam_policy_document.oidc_assume_role.json
 }
 
-# resource "aws_eks_addon" "core-dns" {
-#   depends_on = [
-#     aws_eks_addon.vpc-cni
-#   ]
-#   cluster_name                = var.namespace
-#   addon_name                  = "coredns"
-#   addon_version               = "v1.10.1-eksbuild.4"
-#   resolve_conflicts           = "OVERWRITE"
-# }
+resource "aws_eks_addon" "core-dns" {
+   depends_on = [
+     aws_eks_addon.vpc-cni
+   ]
+   cluster_name               = var.namespace
+   addon_name                 = "aws-efs-csi-driver"
+   addon_version              = "v1.7.7-eksbuild.1"
+   resolve_conflicts          = "OVERWRITE"
+ }
 
 resource "aws_eks_addon" "ebs-csi" {
   depends_on = [
@@ -62,4 +62,5 @@ resource "aws_eks_addon" "vpc-cni" {
   addon_name                  = "vpc-cni"
   addon_version               = "v1.18.0-eksbuild.1"
   resolve_conflicts           = "OVERWRITE"
+  service_account_role_arn = aws_iam_role.oidc.arn
 }

--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -53,7 +53,7 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
 
 resource "aws_eks_addon" "coredns" {
   depends_on = [
-    aws_eks_addon.vpc-cni
+    aws_eks_addon.vpc_cni
   ]
   cluster_name                = var.namespace
   addon_name                  = "coredns"

--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -1,0 +1,65 @@
+
+data "aws_iam_policy_document" "oidc_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:aws-node"]
+    }
+
+    principals {
+      identifiers = [aws_iam_openid_connect_provider.eks.arn]
+      type        = "Federated"
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "eks-oidc" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.oidc.name
+}
+
+resource "aws_iam_role" "oidc" {
+  name               = join("-", [var.namespace, "oidc"])
+  assume_role_policy = data.aws_iam_policy_document.oidc_assume_role.json
+}
+
+# resource "aws_eks_addon" "core-dns" {
+#   depends_on = [
+#     aws_eks_addon.vpc-cni
+#   ]
+#   cluster_name                = var.namespace
+#   addon_name                  = "coredns"
+#   addon_version               = "v1.10.1-eksbuild.4"
+#   resolve_conflicts           = "OVERWRITE"
+# }
+
+resource "aws_eks_addon" "ebs-csi" {
+  depends_on = [
+    aws_eks_addon.vpc-cni
+  ]
+  cluster_name                = var.namespace
+  addon_name                  = "aws-ebs-csi-driver"
+  addon_version               = "v1.25.0-eksbuild.1"
+  resolve_conflicts           = "OVERWRITE"
+}
+
+resource "aws_eks_addon" "kube-proxy" {
+  depends_on = [
+    aws_eks_addon.vpc-cni
+  ]
+  cluster_name                = var.namespace
+  addon_name                  = "kube-proxy"
+  addon_version               = "v1.25.14-eksbuild.2"
+  resolve_conflicts           = "OVERWRITE"
+}
+
+resource "aws_eks_addon" "vpc-cni" {
+  cluster_name                = var.namespace
+  addon_name                  = "vpc-cni"
+  addon_version               = "v1.18.0-eksbuild.1"
+  resolve_conflicts           = "OVERWRITE"
+}

--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -27,7 +27,7 @@ resource "aws_iam_role" "oidc" {
   assume_role_policy = data.aws_iam_policy_document.oidc_assume_role.json
 }
 
-resource "aws_eks_addon" "core-dns" {
+resource "aws_eks_addon" "aws-efs-csi-driver" {
    depends_on = [
      aws_eks_addon.vpc-cni
    ]
@@ -37,13 +37,23 @@ resource "aws_eks_addon" "core-dns" {
    resolve_conflicts          = "OVERWRITE"
  }
 
-resource "aws_eks_addon" "ebs-csi" {
+resource "aws_eks_addon" "aws-ebs-csi-driver" {
   depends_on = [
     aws_eks_addon.vpc-cni
   ]
   cluster_name                = var.namespace
   addon_name                  = "aws-ebs-csi-driver"
   addon_version               = "v1.25.0-eksbuild.1"
+  resolve_conflicts           = "OVERWRITE"
+}
+
+resource "aws_eks_addon" "coredns" {
+  depends_on = [
+    aws_eks_addon.vpc-cni
+  ]
+  cluster_name                = var.namespace
+  addon_name                  = "coredns"
+  addon_version               = "v1.9.3-eksbuild.11"
   resolve_conflicts           = "OVERWRITE"
 }
 

--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -14,13 +14,13 @@ locals {
 }
 
 
-resource "aws_eks_addon" "eks" {
-  cluster_name = var.namespace
-  addon_name   = "aws-ebs-csi-driver"
-  depends_on = [
-    module.eks
-  ]
-}
+# resource "aws_eks_addon" "eks" {
+#   cluster_name = var.namespace
+#   addon_name   = "aws-ebs-csi-driver"
+#   depends_on = [
+#     module.eks
+#   ]
+# }
 
 resource "aws_eks_addon" "efs" {
   cluster_name      = module.eks.cluster_id

--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -14,34 +14,6 @@ locals {
 }
 
 
-# resource "aws_eks_addon" "eks" {
-#   cluster_name = var.namespace
-#   addon_name   = "aws-ebs-csi-driver"
-#   depends_on = [
-#     module.eks
-#   ]
-# }
-
-resource "aws_eks_addon" "efs" {
-  cluster_name      = module.eks.cluster_id
-  addon_name        = "aws-efs-csi-driver"
-  addon_version     = "v1.7.1-eksbuild.1" # Ensure this version is compatible
-  resolve_conflicts = "OVERWRITE"
-  depends_on = [
-    module.eks
-  ]
-}
-
-# removed due to conflict with 
-# AWS Load Balancer Controller
-# being installed with Helm.
-# See: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.6/
-#resource "aws_eks_addon" "vpc_cni" {
-#  cluster_name = var.namespace
-#  addon_name   = "vpc-cni"
-#  depends_on   = [module.eks]
-#}
-
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 17.23"


### PR DESCRIPTION
This PR changes the default version of EKS to 1.26. It also installs the AWS VPC-CNI add-on, and creates an IAM role for that add-on. If you find appying fails because some of the add-ons already exist, remove the add-ons in question using the AWS console or the AWS CLI and re-apply.