### PR TITLE
fix: Amend standard sizes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -11,3 +11,5 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+   .

--- a/deployment-size.tf
+++ b/deployment-size.tf
@@ -7,19 +7,19 @@ locals {
   deployment_size = {
     small = {
       db            = "db.r6g.large",
-      node_count    = 3,
+      node_count    = 2,
       node_instance = "r6i.xlarge"
       cache         = "cache.m6g.large"
     },
     medium = {
       db            = "db.r6g.xlarge",
-      node_count    = 3,
+      node_count    = 2,
       node_instance = "r6i.xlarge"
       cache         = "cache.m6g.large"
     },
     large = {
       db            = "db.r6g.2xlarge",
-      node_count    = 3,
+      node_count    = 2,
       node_instance = "r6i.2xlarge"
       cache         = "cache.m6g.xlarge"
     },


### PR DESCRIPTION
This changes the node count from 3 for all sizes to 2, except xlarge and xxlarge.