### PR TITLE
feat: Update EKS add-ons prior to EKS updgrade

### DIFF
--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -47,7 +47,7 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
   ]
   cluster_name                = var.namespace
   addon_name                  = "aws-ebs-csi-driver"
-  addon_version               = "v1.25.0-eksbuild.1"
+  addon_version               = "v1.31.0-eksbuild.1"
   resolve_conflicts           = "OVERWRITE"
 }
 
@@ -67,14 +67,14 @@ resource "aws_eks_addon" "kube_proxy" {
   ]
   cluster_name                = var.namespace
   addon_name                  = "kube-proxy"
-  addon_version               = "v1.25.14-eksbuild.2"
+  addon_version               = "v1.26.9-eksbuild.2"
   resolve_conflicts           = "OVERWRITE"
 }
 
 resource "aws_eks_addon" "vpc_cni" {
   cluster_name                = var.namespace
   addon_name                  = "vpc-cni"
-  addon_version               = "v1.18.0-eksbuild.1"
+  addon_version               = "v1.18.1-eksbuild.1"
   resolve_conflicts           = "OVERWRITE"
   service_account_role_arn = aws_iam_role.oidc.arn
 }

--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -37,7 +37,7 @@ resource "aws_eks_addon" "aws_efs_csi_driver" {
    ]
    cluster_name               = var.namespace
    addon_name                 = "aws-efs-csi-driver"
-   addon_version              = "v1.7.7-eksbuild.1"
+   addon_version              = "v2.0.2-eksbuild.1"
    resolve_conflicts          = "OVERWRITE"
  }
 


### PR DESCRIPTION
Upgrades EKS add-ons to the following versions:
kube-proxy: v1.26.9-eksbuild.2
efs-csi: v2.0.2-eksbuild.1
ebs-csi: v1.31-eksbuild.1