### PR TITLE
chore: Replace deprecated resolve conflicts field

### DIFF
--- a/modules/app_eks/add-ons.tf
+++ b/modules/app_eks/add-ons.tf
@@ -32,14 +32,15 @@ resource "aws_iam_role" "oidc" {
 
 ### add-ons
 resource "aws_eks_addon" "aws_efs_csi_driver" {
-   depends_on = [
-     aws_eks_addon.vpc_cni
-   ]
-   cluster_name               = var.namespace
-   addon_name                 = "aws-efs-csi-driver"
-   addon_version              = "v1.7.7-eksbuild.1"
-   resolve_conflicts          = "OVERWRITE"
- }
+  depends_on = [
+    aws_eks_addon.vpc_cni
+  ]
+  cluster_name                = var.namespace
+  addon_name                  = "aws-efs-csi-driver"
+  addon_version               = "v1.7.7-eksbuild.1"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+}
 
 resource "aws_eks_addon" "aws_ebs_csi_driver" {
   depends_on = [
@@ -48,7 +49,8 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
   cluster_name                = var.namespace
   addon_name                  = "aws-ebs-csi-driver"
   addon_version               = "v1.25.0-eksbuild.1"
-  resolve_conflicts           = "OVERWRITE"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
 }
 
 resource "aws_eks_addon" "coredns" {
@@ -58,7 +60,8 @@ resource "aws_eks_addon" "coredns" {
   cluster_name                = var.namespace
   addon_name                  = "coredns"
   addon_version               = "v1.9.3-eksbuild.11"
-  resolve_conflicts           = "OVERWRITE"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
 }
 
 resource "aws_eks_addon" "kube_proxy" {
@@ -68,13 +71,15 @@ resource "aws_eks_addon" "kube_proxy" {
   cluster_name                = var.namespace
   addon_name                  = "kube-proxy"
   addon_version               = "v1.25.14-eksbuild.2"
-  resolve_conflicts           = "OVERWRITE"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
 }
 
 resource "aws_eks_addon" "vpc_cni" {
   cluster_name                = var.namespace
   addon_name                  = "vpc-cni"
   addon_version               = "v1.18.0-eksbuild.1"
-  resolve_conflicts           = "OVERWRITE"
-  service_account_role_arn = aws_iam_role.oidc.arn
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  service_account_role_arn    = aws_iam_role.oidc.arn
 }


### PR DESCRIPTION
```
Error: creating EKS Add-On (wandb-qa-aws:vpc-cni): ResourceInUseException: Addon already exists. { RespMetadata: { StatusCode: 409, RequestID: "c38e4e71-d773-42f6-8f27-164471b732bf" }, Message_: "Addon already exists." }
```

![Screenshot 2024-06-17 at 12 37 18 PM](https://github.com/wandb/terraform-aws-wandb/assets/48932219/bfefe815-09e6-4bee-8605-8b1ef285d768)
