### PR TITLE
fix: Pass cloudprovider value to the helm charts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -260,7 +260,7 @@ module "wandb" {
       global = {
         host    = local.url
         license = var.license
-
+        cloudProvider = "aws"
         extraEnv = var.other_wandb_env
 
         bucket = {


### PR DESCRIPTION
Start passing a new value to the helm chart https://github.com/wandb/helm-charts/pull/163/files