### PR TITLE
feat: Upgrade to newer better RDS CA certificates

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -102,6 +102,7 @@ module "aurora" {
   apply_immediately                   = true
   autoscaling_enabled                 = false
   backup_retention_period             = var.backup_retention_period
+  ca_cert_identifier                  = "rds-ca-ecc384-g1"
   create_db_subnet_group              = var.create_db_subnet_group
   create_random_password              = false
   create_security_group               = true


### PR DESCRIPTION
Currently in use RDS CA is expiring in August, so we need to migrate to one of the newer CAs