### PR TITLE
fix: Don't create KMS key and related resources for CH by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ module "kms" {
   key_alias  = var.kms_key_alias == null ? "${var.namespace}-kms-alias" : var.kms_key_alias
   key_policy = var.kms_key_policy
 
+  create_clickhouse_key = var.enable_clickhouse
   clickhouse_key_alias  = var.kms_clickhouse_key_alias == null ? "${var.namespace}-kms-clickhouse-alias" : var.kms_clickhouse_key_alias
   clickhouse_key_policy = var.kms_clickhouse_key_policy
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ module "kms" {
 locals {
 
   default_kms_key                           = module.kms.key.arn
-  clickhouse_kms_key                        = module.kms.clickhouse_key.arn
+  clickhouse_kms_key                        = var.enable_clickhouse ? module.kms.clickhouse_key.arn : null
   s3_kms_key_arn                            = length(var.bucket_kms_key_arn) > 0 ? var.bucket_kms_key_arn : local.default_kms_key
   database_kms_key_arn                      = length(var.database_kms_key_arn) > 0 ? var.database_kms_key_arn : local.default_kms_key
   database_performance_insights_kms_key_arn = length(var.database_performance_insights_kms_key_arn) > 0 ? var.database_performance_insights_kms_key_arn : local.default_kms_key

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -143,7 +143,7 @@ resource "aws_kms_alias" "clickhouse_key" {
 
 
 resource "aws_kms_grant" "clickhouse" {
-  count = var.create_clickhouse_key && (var.iam_principal_arn == "") ? 0 : 1
+  count = !var.create_clickhouse_key && (var.iam_principal_arn == "") ? 0 : 1
 
   grantee_principal = var.iam_principal_arn
   key_id            = aws_kms_key.clickhouse_key[0].key_id

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -138,7 +138,7 @@ resource "aws_kms_alias" "clickhouse_key" {
   count = var.create_clickhouse_key ? 1 : 0
 
   name          = "alias/${var.clickhouse_key_alias}"
-  target_key_id = aws_kms_key.clickhouse_key.key_id
+  target_key_id = aws_kms_key.clickhouse_key[0].key_id
 }
 
 
@@ -146,7 +146,7 @@ resource "aws_kms_grant" "clickhouse" {
   count = var.create_clickhouse_key && (var.iam_principal_arn == "") ? 0 : 1
 
   grantee_principal = var.iam_principal_arn
-  key_id            = aws_kms_key.clickhouse_key.key_id
+  key_id            = aws_kms_key.clickhouse_key[0].key_id
   operations = [
     "Decrypt",
     "DescribeKey",

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -91,6 +91,8 @@ resource "aws_kms_grant" "main" {
 }
 
 resource "aws_kms_key" "clickhouse_key" {
+  count = var.create_clickhouse_key ? 1 : 0
+
   deletion_window_in_days = var.key_deletion_window
   description             = "AWS KMS Customer-managed key to encrypt Weave resources in Clickhouse"
   key_usage               = "ENCRYPT_DECRYPT"
@@ -133,13 +135,15 @@ resource "aws_kms_key" "clickhouse_key" {
 
 
 resource "aws_kms_alias" "clickhouse_key" {
+  count = var.create_clickhouse_key ? 1 : 0
+
   name          = "alias/${var.clickhouse_key_alias}"
   target_key_id = aws_kms_key.clickhouse_key.key_id
 }
 
 
 resource "aws_kms_grant" "clickhouse" {
-  count = var.iam_principal_arn == "" ? 0 : 1
+  count = var.create_clickhouse_key && (var.iam_principal_arn == "") ? 0 : 1
 
   grantee_principal = var.iam_principal_arn
   key_id            = aws_kms_key.clickhouse_key.key_id

--- a/modules/kms/outputs.tf
+++ b/modules/kms/outputs.tf
@@ -5,6 +5,6 @@ output "key" {
 
 
 output "clickhouse_key" {
-  value       = aws_kms_key.clickhouse_key
+  value       = var.create_clickhouse_key ? aws_kms_key.clickhouse_key[0] : null
   description = "The KMS key used to encrypt Weave data in Clickhouse."
 }

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -20,9 +20,16 @@ variable "key_policy" {
   default     = ""
 }
 
+variable "create_clickhouse_key" {
+  description = "Whether to create a KMS key for Clickhouse CMEK."
+  type        = bool
+  default     = false
+}
+
 variable "clickhouse_key_alias" {
   description = "The key alias for AWS KMS Customer managed key."
   type        = string
+  default     = "wandb-kms-clickhouse-key"
 }
 
 variable "clickhouse_key_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -487,8 +487,14 @@ variable "yace_sa_name" {
   default = "wandb-yace"
 }
 
+variable "enable_clickhouse" {
+  type        = bool
+  description = "Provision clickhouse resources"
+  default     = false
+}
+
 variable "clickhouse_endpoint_service_id" {
   type        = string
-  description = "The service ID of the VPC endpoint service for Clickhouse."
+  description = "The service ID of the VPC endpoint service for Clickhouse"
   default     = ""
 }


### PR DESCRIPTION
- [x] Following up from previous change, don't create KMS keys for clickhouse by default.