### PR TITLE
feat: Add optional path var for instance level bucket path

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Upgrades must be executed in step-wise fashion from one version to the next. You
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
 | <a name="output_bucket_queue_name"></a> [bucket\_queue\_name](#output\_bucket\_queue\_name) | n/a |
 | <a name="output_bucket_region"></a> [bucket\_region](#output\_bucket\_region) | n/a |
+| <a name="output_bucket_path"></a> [bucket\_path](#output\_bucket\_path) | n/a |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | n/a |
 | <a name="output_cluster_node_role"></a> [cluster\_node\_role](#output\_cluster\_node\_role) | n/a |
 | <a name="output_database_connection_string"></a> [database\_connection\_string](#output\_database\_connection\_string) | n/a |

--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ Upgrades must be executed in step-wise fashion from one version to the next. You
 | Name | Description |
 |------|-------------|
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
+| <a name="output_bucket_path"></a> [bucket\_path](#output\_bucket\_path) | n/a |
 | <a name="output_bucket_queue_name"></a> [bucket\_queue\_name](#output\_bucket\_queue\_name) | n/a |
 | <a name="output_bucket_region"></a> [bucket\_region](#output\_bucket\_region) | n/a |
-| <a name="output_bucket_path"></a> [bucket\_path](#output\_bucket\_path) | n/a |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | n/a |
 | <a name="output_cluster_node_role"></a> [cluster\_node\_role](#output\_cluster\_node\_role) | n/a |
 | <a name="output_database_connection_string"></a> [database\_connection\_string](#output\_database\_connection\_string) | n/a |

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Upgrades must be executed in step-wise fashion from one version to the next. You
 | <a name="input_aws_loadbalancer_controller_tags"></a> [aws\_loadbalancer\_controller\_tags](#input\_aws\_loadbalancer\_controller\_tags) | (Optional) A map of AWS tags to apply to all resources managed by the load balancer controller | `map(string)` | `{}` | no |
 | <a name="input_bucket_kms_key_arn"></a> [bucket\_kms\_key\_arn](#input\_bucket\_kms\_key\_arn) | n/a | `string` | `""` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | n/a | `string` | `""` | no |
+| <a name="input_bucket_path"></a> [bucket\_path](#input\_bucket\_path) | path of where to store data for the instance-level bucket | `string` | `""` | no |
 | <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | ######################################### External Bucket                        # ######################################### Most users will not need these settings. They are ment for users who want a bucket and sqs that are in a different account. | `bool` | `true` | no |
 | <a name="input_create_elasticache"></a> [create\_elasticache](#input\_create\_elasticache) | Boolean indicating whether to provision an elasticache instance (true) or not (false). | `bool` | `true` | no |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Boolean indicating whether to deploy a VPC (true) or not (false). | `bool` | `true` | no |

--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -117,6 +117,10 @@ output "bucket_name" {
   value = module.wandb_infra.bucket_name
 }
 
+output "bucket_path" {
+  value = module.wandb_infra.bucket_path
+}
+
 output "bucket_queue_name" {
   value = module.wandb_infra.bucket_queue_name
 }

--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -91,6 +91,7 @@ module "wandb_app" {
 
   host                       = module.wandb_infra.url
   bucket                     = "s3://${module.wandb_infra.bucket_name}"
+  bucket_path                = var.bucket_path
   bucket_aws_region          = module.wandb_infra.bucket_region
   bucket_queue               = "internal://"
   bucket_kms_key_arn         = module.wandb_infra.kms_key_arn

--- a/examples/public-dns-external/main.tf
+++ b/examples/public-dns-external/main.tf
@@ -39,6 +39,7 @@ module "wandb_infra" {
   license = var.wandb_license
 
   bucket_name        = var.bucket_name
+  bucket_path        = var.bucket_path
   bucket_kms_key_arn = var.bucket_kms_key_arn
   use_internal_queue = true
   size               = var.size

--- a/examples/public-dns-external/variables.tf
+++ b/examples/public-dns-external/variables.tf
@@ -77,6 +77,11 @@ variable "bucket_kms_key_arn" {
   default     = ""
 }
 
+variable "bucket_path" {
+  description = "path of where to store data for the instance-level bucket"
+  type        = string
+  default     = ""
+}
 
 variable "allowed_inbound_cidr" {
   default  = ["0.0.0.0/0"]

--- a/main.tf
+++ b/main.tf
@@ -278,6 +278,7 @@ module "wandb" {
         bucket = {
           provider = "s3"
           name     = local.bucket_name
+          path     = var.bucket_path
           region   = data.aws_s3_bucket.file_storage.region
           kmsKey   = local.s3_kms_key_arn
         }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,6 +7,10 @@ output "bucket_queue_name" {
 output "bucket_region" {
   value = data.aws_s3_bucket.file_storage.region
 }
+output "bucket_path" {
+  value = var.bucket_path
+}
+
 output "cluster_id" {
   value = module.app_eks.cluster_id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,14 @@
 output "bucket_name" {
   value = local.bucket_name
 }
+output "bucket_path" {
+  value = var.bucket_path
+}
 output "bucket_queue_name" {
   value = local.bucket_queue_name
 }
 output "bucket_region" {
   value = data.aws_s3_bucket.file_storage.region
-}
-output "bucket_path" {
-  value = var.bucket_path
 }
 
 output "cluster_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -430,6 +430,18 @@ variable "bucket_kms_key_arn" {
 }
 
 ##########################################
+# Bucket path                            #
+##########################################
+# This setting is meant for users who want to store all of their instance-level
+# bucket's data at a specific path within their bucket. It can be set both for
+# external buckets or the bucket created by this module.
+variable "bucket_path" {
+  description = "path of where to store data for the instance-level bucket"
+  type        = string
+  default     = ""
+}
+
+##########################################
 # Redis                                  #
 ##########################################
 variable "create_elasticache" {


### PR DESCRIPTION
```
  # module.wandb_infra.module.wandb.helm_release.wandb will be updated in-place
  ~ resource "helm_release" "wandb" {
        id                         = "wandb-cr"
      ~ metadata                   = [
          - {
              ...
              - values         = jsonencode(
                    {
                      - name = "wandb"
                      - spec = <<-EOT
                            "values":
                              "app": {}
                              "global":
                                "bucket":
                                  "kmsKey": "arn:aws:kms:us-west-2:770934259321:key/c88a4da3-aabd-4265-a57d-e4f0115d04b8"
                                  "name": "levin-aws-subpath-testing-file-storage-unbiased-chimp"
                                  "path": ""
                                  "provider": "s3"
                                  "region": "us-west-2"
                                "cloudProvider": "aws"
                         ...
                        EOT
                    }
                )
              - version        = "0.1.0"
            },
        ] -> (known after apply)
        name                       = "wandb-cr"
        # (26 unchanged attributes hidden)

      - set {
          - name  = "spec" -> null
          - type  = "string" -> null
          - value = <<-EOT
                "values":
                  "app": {}
                  "global":
                    "bucket":
                      "kmsKey": "arn:aws:kms:us-west-2:770934259321:key/c88a4da3-aabd-4265-a57d-e4f0115d04b8"
                      "name": "levin-aws-subpath-testing-file-storage-unbiased-chimp"
                      "path": ""
                      "provider": "s3"
                      "region": "us-west-2"
                    "cloudProvider": "aws"
 
            EOT -> null
        }
      + set {
          + name  = "spec"
          + type  = "string"
          + value = <<-EOT
                "values":
                  "app": {}
                  "global":
                    "bucket":
                      "kmsKey": "arn:aws:kms:us-west-2:770934259321:key/c88a4da3-aabd-4265-a57d-e4f0115d04b8"
                      "name": "levin-aws-subpath-testing-file-storage-unbiased-chimp"
                      "path": "nested/path"
                      "provider": "s3"
                      "region": "us-west-2"
                    "cloudProvider": "aws"
 ...
            EOT
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```