### PR TITLE
fix: kms policy for root user

### DIFF
--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -22,14 +22,7 @@ resource "aws_kms_key" "key" {
           "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
         },
         "Action" : [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:Describe*",
-          "kms:Get*",
-          "kms:List*",
-          "kms:RevokeGrant"
+          "kms:*",
         ],
         "Resource" : "*"
       },


### PR DESCRIPTION
KMS policies has its own permissions which allows specific users to take certain actions. These permissions override regular IAM permissions and therefore need to be configured correctly during creation. This change allows the root user (as well as other users assigned our kmsAdmin role) to modify/delete kms keys and successfully clean up the environment. 

Due to the way AWS wires its permission sets, this config change is required so that when an IAM user is granted an kmsAdmin role, it will be able to assume kms* policies instead of the limited policies previously specified.