### PR TITLE
fix: Adding CreateGrant to KMS key actions in KMS key policy for CMEK

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,8 @@ This can be donw by adding the following policy document.
         "kms:Decrypt",
         "kms:ReEncrypt*",
         "kms:GenerateDataKey*",
-        "kms:DescribeKey"
+        "kms:DescribeKey",
+        "kms:CreateGrant"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
Customer Managed Encryption Keys for databases requires additional KMS key actions in the the policy. Particularly `kms:CreateGrant`. This PR updates the documented KMS key policy to include this action in the README.md.