### PR TITLE
feat: Add internalJWTMap variables used for inter service request authentication

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -327,8 +327,8 @@ module "wandb" {
       app = {
         internalJWTMap = [
           {
-            "subject" = "system:serviceaccount:${var.namespace}:${local.weave_trace_sa_name}",
-            "issuer"  = var.weave_trace_service_account_issuer_url
+            "subject" = "system:serviceaccount:default:${local.weave_trace_sa_name}",
+            "issuer"  = var.kubernetes_cluster_oidc_issuer_url
           }
         ]
       }

--- a/main.tf
+++ b/main.tf
@@ -246,6 +246,10 @@ module "iam_role" {
   aws_iam_openid_connect_provider_url = module.app_eks.aws_iam_openid_connect_provider
 }
 
+locals {
+  weave_trace_sa_name = "wandb-weave-trace"
+}
+
 module "wandb" {
   source  = "wandb/wandb/helm"
   version = "1.2.0"
@@ -320,7 +324,14 @@ module "wandb" {
 
       }
 
-      app = {}
+      app = {
+        internalJWTMap = [
+          {
+            "subject" = "system:serviceaccount:${var.namespace}:${local.weave_trace_sa_name}",
+            "issuer"  = var.weave_trace_service_account_issuer_url
+          }
+        ]
+      }
 
       # To support otel rds and redis metrics, we need operator-wandb chart min version 0.13.8 (yace subchart)
       yace = var.enable_yace ? {

--- a/variables.tf
+++ b/variables.tf
@@ -522,3 +522,9 @@ variable "clickhouse_endpoint_service_id" {
   description = "The service ID of the VPC endpoint service for Clickhouse"
   default     = ""
 }
+
+variable "weave_trace_service_account_issuer_url" {
+  type        = string
+  description = "The issuer URL of the service account for Weave Trace"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -523,8 +523,12 @@ variable "clickhouse_endpoint_service_id" {
   default     = ""
 }
 
-variable "weave_trace_service_account_issuer_url" {
+##########################################
+# Internal Service                       #
+##########################################
+
+variable "kubernetes_cluster_oidc_issuer_url" {
   type        = string
-  description = "The issuer URL of the service account for Weave Trace"
+  description = "OIDC issuer URL for the Kubernetes cluster. Can be determined using `kubectl get --raw /.well-known/openid-configuration`"
   default     = ""
 }


### PR DESCRIPTION
Adds a new variable kubernetes_cluster_oidc_issuer_url variable, and a local variable defining the weave trace server service account name. These two values are used to set the internalJWTMap value in our helm charts which defines the mapping of subject to issuer, which is used to authenticate internal service communication