### PR TITLE
feat: Add VPC flow logs option + s3 https-only policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,12 +29,13 @@ locals {
 }
 
 module "file_storage" {
-  source              = "./modules/file_storage"
-  namespace           = var.namespace
-  create_queue        = !local.use_internal_queue
-  sse_algorithm       = "aws:kms"
-  kms_key_arn         = local.s3_kms_key_arn
-  deletion_protection = var.deletion_protection
+  source               = "./modules/file_storage"
+  namespace            = var.namespace
+  create_queue         = !local.use_internal_queue
+  sse_algorithm        = "aws:kms"
+  kms_key_arn          = local.s3_kms_key_arn
+  deletion_protection  = var.deletion_protection
+  enable_s3_https_only = var.enable_s3_https_only
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,7 @@ module "networking" {
   source     = "./modules/networking"
   namespace  = var.namespace
   create_vpc = var.create_vpc
+  enable_flow_log = var.enable_flow_log
 
   cidr                           = var.network_cidr
   private_subnet_cidrs           = var.network_private_subnet_cidrs

--- a/main.tf
+++ b/main.tf
@@ -43,9 +43,9 @@ locals {
 }
 
 module "networking" {
-  source     = "./modules/networking"
-  namespace  = var.namespace
-  create_vpc = var.create_vpc
+  source          = "./modules/networking"
+  namespace       = var.namespace
+  create_vpc      = var.create_vpc
   enable_flow_log = var.enable_flow_log
 
   cidr                           = var.network_cidr

--- a/modules/file_storage/main.tf
+++ b/modules/file_storage/main.tf
@@ -21,6 +21,32 @@ resource "aws_s3_bucket" "file_storage" {
   depends_on = [aws_sqs_queue.file_storage]
 }
 
+# Apply an HTTPS-only bucket policy to each bucket
+resource "aws_s3_bucket_policy" "https_only" {
+  bucket = aws_s3_bucket.file_storage.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "DenyHTTPRequests",
+        Effect    = "Deny",
+        Principal = "*",
+        Action    = "s3:*",
+        Resource  = [
+          "arn:aws:s3:::${aws_s3_bucket.file_storage.bucket}",
+          "arn:aws:s3:::${aws_s3_bucket.file_storage.bucket}/*"
+        ],
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_s3_bucket_acl" "file_storage" {
   depends_on = [aws_s3_bucket_ownership_controls.file_storage]
 

--- a/modules/file_storage/main.tf
+++ b/modules/file_storage/main.tf
@@ -33,7 +33,7 @@ resource "aws_s3_bucket_policy" "https_only" {
         Effect    = "Deny",
         Principal = "*",
         Action    = "s3:*",
-        Resource  = [
+        Resource = [
           "arn:aws:s3:::${aws_s3_bucket.file_storage.bucket}",
           "arn:aws:s3:::${aws_s3_bucket.file_storage.bucket}/*"
         ],

--- a/modules/file_storage/main.tf
+++ b/modules/file_storage/main.tf
@@ -23,6 +23,7 @@ resource "aws_s3_bucket" "file_storage" {
 
 # Apply an HTTPS-only bucket policy to each bucket
 resource "aws_s3_bucket_policy" "https_only" {
+  count  = var.enable_s3_https_only ? 1 : 0
   bucket = aws_s3_bucket.file_storage.id
 
   policy = jsonencode({

--- a/modules/file_storage/variables.tf
+++ b/modules/file_storage/variables.tf
@@ -32,3 +32,9 @@ variable "create_queue_policy" {
   type        = bool
   default     = true
 }
+
+variable "enable_s3_https_only" {
+  description = "Controls whether HTTPS-only is enabled for s3 buckets"
+  type        = bool
+  default     = false
+}

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -39,7 +39,7 @@ module "vpc" {
 }
 
 resource "aws_vpc_endpoint" "clickhouse" {
-  count = var.create_vpc && var.clickhouse_endpoint_service_id != "" ? 1 : 0
+  count = var.create_vpc && length(var.clickhouse_endpoint_service_id) > 0 ? 1 : 0
 
   vpc_id              = module.vpc.vpc_id
   service_name        = var.clickhouse_endpoint_service_id
@@ -59,5 +59,5 @@ resource "aws_flow_log" "vpc_flow_logs" {
 }
 
 resource "aws_s3_bucket" "flow_log" {
-  bucket = "vpc-logs"
+  bucket = "${var.namespace}-vpc-flow-logs"
 }

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -20,7 +20,7 @@ module "vpc" {
   elasticache_subnets            = var.create_elasticache_subnet ? var.elasticache_subnet_cidrs : []
   enable_dns_hostnames           = true
   enable_dns_support             = true
-  enable_vpc_flow_logs           = var.enable_vpc_flow_logs
+  enable_flow_logs           = var.enable_flow_logs
   enable_nat_gateway             = true
   enable_vpn_gateway             = var.enable_vpn_gateway
   manage_default_security_group  = true

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -20,7 +20,7 @@ module "vpc" {
   elasticache_subnets            = var.create_elasticache_subnet ? var.elasticache_subnet_cidrs : []
   enable_dns_hostnames           = true
   enable_dns_support             = true
-  enable_flow_logs           = var.enable_flow_logs
+  enable_flow_log                = var.enable_flow_log
   enable_nat_gateway             = true
   enable_vpn_gateway             = var.enable_vpn_gateway
   manage_default_security_group  = true

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -20,6 +20,7 @@ module "vpc" {
   elasticache_subnets            = var.create_elasticache_subnet ? var.elasticache_subnet_cidrs : []
   enable_dns_hostnames           = true
   enable_dns_support             = true
+  enable_vpc_flow_logs           = var.enable_vpc_flow_logs
   enable_nat_gateway             = true
   enable_vpn_gateway             = var.enable_vpn_gateway
   manage_default_security_group  = true

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -59,5 +59,7 @@ resource "aws_flow_log" "vpc_flow_logs" {
 }
 
 resource "aws_s3_bucket" "flow_log" {
+  count = var.create_vpc && var.enable_flow_log ? 1 : 0
+  
   bucket = "${var.namespace}-vpc-flow-logs"
 }

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -60,6 +60,6 @@ resource "aws_flow_log" "vpc_flow_logs" {
 
 resource "aws_s3_bucket" "flow_log" {
   count = var.create_vpc && var.enable_flow_log ? 1 : 0
-  
+
   bucket = "${var.namespace}-vpc-flow-logs"
 }

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -52,7 +52,7 @@ resource "aws_vpc_endpoint" "clickhouse" {
 resource "aws_flow_log" "vpc_flow_logs" {
   count = var.create_vpc && var.enable_flow_log ? 1 : 0
 
-  log_destination      = aws_s3_bucket.flow_log.arn
+  log_destination      = aws_s3_bucket.flow_log[0].arn
   log_destination_type = "s3"
   traffic_type         = "REJECT"
   vpc_id               = module.vpc.vpc_id

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -50,7 +50,7 @@ resource "aws_vpc_endpoint" "clickhouse" {
 
 # VPC FLow Logs
 resource "aws_flow_log" "vpc_flow_logs" {
-  count = var.create_vpc && var.enable_flow_log != "" ? 1 : 0
+  count = var.create_vpc && var.enable_flow_log ? 1 : 0
 
   log_destination      = aws_s3_bucket.flow_log.arn
   log_destination_type = "s3"

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -39,7 +39,7 @@ module "vpc" {
 }
 
 resource "aws_vpc_endpoint" "clickhouse" {
-  count = var.create_vpc && var.clickhouse_endpoint_service_id
+  count = var.create_vpc && var.clickhouse_endpoint_service_id != "" ? 1 : 0
 
   vpc_id              = module.vpc.vpc_id
   service_name        = var.clickhouse_endpoint_service_id

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -45,12 +45,6 @@ variable "create_elasticache_subnet" {
   default     = false
 }
 
-variable "enable_flow_log" {
-  description = "Controls whether VPC Flow Logs are enabled"
-  type        = bool
-  default     = false
-}
-
 variable "enable_vpn_gateway" {
   type        = bool
   description = "(Optional) Should be true if you want to create a new VPN Gateway resource and attach it to the VPC."
@@ -73,4 +67,10 @@ variable "clickhouse_endpoint_service_id" {
   description = "The ID of the Clickhouse service endpoint"
   type        = string
   default     = ""
+}
+
+variable "enable_flow_log" {
+  description = "Controls whether VPC Flow Logs are enabled"
+  type        = bool
+  default     = false
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -45,6 +45,12 @@ variable "create_elasticache_subnet" {
   default     = false
 }
 
+variable "enable_vpc_flow_logs" {
+  description = "Whether to enable VPC Flow Logs"
+  type        = bool
+  default     = false
+}
+
 variable "enable_vpn_gateway" {
   type        = bool
   description = "(Optional) Should be true if you want to create a new VPN Gateway resource and attach it to the VPC."

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -46,7 +46,7 @@ variable "create_elasticache_subnet" {
 }
 
 variable "enable_vpc_flow_logs" {
-  description = "Whether to enable VPC Flow Logs"
+  description = "Controls whether VPC Flow Logs are enabled"
   type        = bool
   default     = false
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -45,7 +45,7 @@ variable "create_elasticache_subnet" {
   default     = false
 }
 
-variable "enable_vpc_flow_logs" {
+variable "enable_flow_logs" {
   description = "Controls whether VPC Flow Logs are enabled"
   type        = bool
   default     = false

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -45,7 +45,7 @@ variable "create_elasticache_subnet" {
   default     = false
 }
 
-variable "enable_flow_logs" {
+variable "enable_flow_log" {
   description = "Controls whether VPC Flow Logs are enabled"
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -214,6 +214,12 @@ variable "create_vpc" {
   default     = true
 }
 
+variable "enable_flow_log" {
+  description = "Controls whether VPC Flow Logs are enabled"
+  type        = bool
+  default     = false
+}
+
 variable "network_id" {
   default     = ""
   description = "The identity of the VPC in which resources will be deployed."

--- a/variables.tf
+++ b/variables.tf
@@ -444,6 +444,17 @@ variable "eks_addon_metrics_server_version" {
 }
 
 ##########################################
+# Bucket Policy                          #
+##########################################
+# This setting will ensure that s3 bucket objects will reject HTTP traffic with a 403
+# and will only accept HTTPS traffic
+variable "enable_s3_https_only" {
+  description = "Controls whether HTTPS-only is enabled for s3 buckets"
+  type        = bool
+  default     = false
+}
+
+##########################################
 # External Bucket                        #
 ##########################################
 # Most users will not need these settings. They are ment for users who want a
@@ -546,3 +557,4 @@ variable "kubernetes_cluster_oidc_issuer_url" {
   description = "OIDC issuer URL for the Kubernetes cluster. Can be determined using `kubectl get --raw /.well-known/openid-configuration`"
   default     = ""
 }
+


### PR DESCRIPTION
Added a boolean flag to enable or disable VPC Flow Logs. Default is set to disable.

Configured VPC Flow Logs to log REJECTED traffic only, focusing on denied network activity for enhanced security and compliance.

Implemented a feature to enforce the rejection of HTTP traffic for S3 buckets. This is also an optional feature.
