### PR TITLE
fix: S3 bucket force destroy

### DIFF
--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -59,7 +59,7 @@ resource "aws_flow_log" "vpc_flow_logs" {
 }
 
 resource "aws_s3_bucket" "flow_log" {
-  count = var.create_vpc && var.enable_flow_log ? 1 : 0
-
-  bucket = "${var.namespace}-vpc-flow-logs"
+  count         = var.create_vpc && var.enable_flow_log ? 1 : 0
+  bucket        = "${var.namespace}-vpc-flow-logs"
+  force_destroy = true
 }


### PR DESCRIPTION
If user disables VPC Flow logs, the associated s3 bucket will be force destroyed.