### PR TITLE
fix: S3 bucket force destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,10 +44,11 @@ locals {
 }
 
 module "networking" {
-  source          = "./modules/networking"
-  namespace       = var.namespace
-  create_vpc      = var.create_vpc
-  enable_flow_log = var.enable_flow_log
+  source               = "./modules/networking"
+  namespace            = var.namespace
+  create_vpc           = var.create_vpc
+  enable_flow_log      = var.enable_flow_log
+  keep_flow_log_bucket = var.keep_flow_log_bucket
 
   cidr                           = var.network_cidr
   private_subnet_cidrs           = var.network_private_subnet_cidrs

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -59,7 +59,7 @@ resource "aws_flow_log" "vpc_flow_logs" {
 }
 
 resource "aws_s3_bucket" "flow_log" {
-  count = var.create_vpc && var.enable_flow_log ? 1 : 0
-
-  bucket = "${var.namespace}-vpc-flow-logs"
+  count         = var.create_vpc && var.enable_flow_log ? 1 : 0
+  bucket        = "${var.namespace}-vpc-flow-logs"
+  force_destroy = true
 }

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -59,7 +59,7 @@ resource "aws_flow_log" "vpc_flow_logs" {
 }
 
 resource "aws_s3_bucket" "flow_log" {
-  count         = var.create_vpc && var.enable_flow_log ? 1 : 0
+  count         = (var.create_vpc && var.enable_flow_log) || var.keep_flow_log_bucket ? 1 : 0
   bucket        = "${var.namespace}-vpc-flow-logs"
   force_destroy = true
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -78,5 +78,5 @@ variable "enable_flow_log" {
 variable "keep_flow_log_bucket" {
   description = "Controls whether S3 bucket storing VPC Flow Logs will be kept"
   type        = bool
-  default     = false
+  default     = true
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -74,3 +74,9 @@ variable "enable_flow_log" {
   type        = bool
   default     = false
 }
+
+variable "keep_flow_log_bucket" {
+  description = "Controls whether S3 bucket storing VPC Flow Logs will be kept"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -223,7 +223,7 @@ variable "enable_flow_log" {
 variable "keep_flow_log_bucket" {
   description = "Controls whether S3 bucket storing VPC Flow Logs will be kept"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "network_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -220,6 +220,12 @@ variable "enable_flow_log" {
   default     = false
 }
 
+variable "keep_flow_log_bucket" {
+  description = "Controls whether S3 bucket storing VPC Flow Logs will be kept"
+  type        = bool
+  default     = false
+}
+
 variable "network_id" {
   default     = ""
   description = "The identity of the VPC in which resources will be deployed."


### PR DESCRIPTION
If a user disables VPC Flow Logs, the associated s3 bucket which stores these logs will be force deleted.