### PR TITLE
fix: S3 https-only

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ module "networking" {
   create_vpc           = var.create_vpc
   enable_flow_log      = var.enable_flow_log
   keep_flow_log_bucket = var.keep_flow_log_bucket
+  enable_s3_https_only = var.enable_s3_https_only
 
   cidr                           = var.network_cidr
   private_subnet_cidrs           = var.network_private_subnet_cidrs

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -80,3 +80,9 @@ variable "keep_flow_log_bucket" {
   type        = bool
   default     = true
 }
+
+variable "enable_s3_https_only" {
+  description = "Controls whether HTTPS-only is enabled for s3 buckets"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Option to deny HTTP traffic on S3 bucket containing VPC Flow Logs