### PR TITLE
fix: S3 https-only policy for VPC Flow Logs bucket

### DIFF
--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -73,12 +73,12 @@ resource "aws_s3_bucket_policy" "flow_log_https_only" {
     Statement = [
       # Allow VPC flow logs to write to the S3 bucket
       {
-        Sid       = "AllowVPCFlowLogsWrite",
-        Effect    = "Allow",
+        Sid    = "AllowVPCFlowLogsWrite",
+        Effect = "Allow",
         Principal = {
           Service = "delivery.logs.amazonaws.com"
         },
-        Action    = "s3:PutObject",
+        Action   = "s3:PutObject",
         Resource = "arn:aws:s3:::${aws_s3_bucket.flow_log[0].bucket}/*",
         Condition = {
           StringEquals = {

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -71,6 +71,22 @@ resource "aws_s3_bucket_policy" "flow_log_https_only" {
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
+      # Allow VPC flow logs to write to the S3 bucket
+      {
+        Sid       = "AllowVPCFlowLogsWrite",
+        Effect    = "Allow",
+        Principal = {
+          Service = "delivery.logs.amazonaws.com"
+        },
+        Action    = "s3:PutObject",
+        Resource = "arn:aws:s3:::${aws_s3_bucket.flow_log[0].bucket}/*",
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl" = "bucket-owner-full-control"
+          }
+        }
+      },
+      # Deny all HTTP requests (HTTPS-only policy)
       {
         Sid       = "DenyHTTPRequests",
         Effect    = "Deny",


### PR DESCRIPTION
Exception for VPC service to send logs to s3 bucket via HTTP