### PR TITLE
fix: Add tag to cloud-managed k8s for cache_size

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -191,7 +191,7 @@ module "app_eks" {
   eks_addon_vpc_cni_version        = var.eks_addon_vpc_cni_version
   eks_addon_metrics_server_version = var.eks_addon_metrics_server_version
 
-  cache_size                       = var.cache_size
+  cache_size = var.cache_size
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -190,6 +190,8 @@ module "app_eks" {
   eks_addon_kube_proxy_version     = var.eks_addon_kube_proxy_version
   eks_addon_vpc_cni_version        = var.eks_addon_vpc_cni_version
   eks_addon_metrics_server_version = var.eks_addon_metrics_server_version
+
+  cache_size                       = var.cache_size
 }
 
 

--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -79,6 +79,7 @@ module "eks" {
     GithubOrg          = "terraform-aws-wandb"
     TerraformNamespace = var.namespace
     TerraformModule    = "terraform-aws-wandb/module/app_eks"
+    cache_size         = var.cache_size
   })
 }
 

--- a/modules/app_eks/variables.tf
+++ b/modules/app_eks/variables.tf
@@ -199,3 +199,13 @@ variable "eks_addon_metrics_server_version" {
   description = "The version of the metrics-server addon to install. Check compatibility with `aws eks describe-addon-versions --region $REGION --kubernetes-version $EKS_CLUSTER_VERSION`"
   type        = string
 }
+
+variable "cache_size" {
+  description = "Size of the redis cache, when use_ctrlplane_redis is true. These values map to preset sizes in the bitnami helm chart."
+  type        = string
+  default     = "nano"
+  validation {
+    condition     = contains(["nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"], var.cache_size)
+    error_message = "Invalid value specified for 'cache_size'; must be one of 'nano', 'micro', 'small', 'medium', 'large'"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -556,6 +556,15 @@ variable "use_ctrlplane_redis" {
   default     = false
 }
 
+variable "cache_size" {
+  description = "Size of the redis cache, when use_ctrlplane_redis is true. These values map to preset sizes in the bitnami helm chart."
+  type        = string
+  default     = "nano"
+  validation {
+    condition     = contains(["nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"], var.cache_size)
+    error_message = "Invalid value specified for 'cache_size'; must be one of 'nano', 'micro', 'small', 'medium', 'large'"
+  }
+}
 
 ##########################################
 # Weights & Biases                       #


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option that lets you specify the Redis cache size when the caching feature is enabled, providing enhanced control over deployment.
  - Added robust input validation to ensure the cache size is set to one of the allowed options: nano, micro, small, medium, large, xlarge, or 2xlarge, reducing the risk of misconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->