### PR TITLE
fix: Tag the aws eks with cache_size, not all resources

### DIFF
--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -79,8 +79,11 @@ module "eks" {
     GithubOrg          = "terraform-aws-wandb"
     TerraformNamespace = var.namespace
     TerraformModule    = "terraform-aws-wandb/module/app_eks"
-    cache_size         = var.cache_size
   })
+
+  cluster_tags = {
+    cache_size         = var.cache_size
+  }
 }
 
 resource "kubernetes_annotations" "gp2" {

--- a/modules/app_eks/main.tf
+++ b/modules/app_eks/main.tf
@@ -82,7 +82,7 @@ module "eks" {
   })
 
   cluster_tags = {
-    cache_size         = var.cache_size
+    cache_size = var.cache_size
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the organization of configuration settings for enhanced clarity, while maintaining all current functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->