### PR TITLE
fix: Bump k8s max nodes by 2

### DIFF
--- a/deployment-size.tf
+++ b/deployment-size.tf
@@ -8,35 +8,35 @@ locals {
     small = {
       db               = "db.r6g.large",
       min_nodes_per_az = 1,
-      max_nodes_per_az = 2,
+      max_nodes_per_az = 4,
       node_instance    = "r6i.xlarge"
       cache            = "cache.m6g.large"
     },
     medium = {
       db               = "db.r6g.xlarge",
       min_nodes_per_az = 1,
-      max_nodes_per_az = 2,
+      max_nodes_per_az = 4,
       node_instance    = "r6i.xlarge"
       cache            = "cache.m6g.large"
     },
     large = {
       db               = "db.r6g.2xlarge",
       min_nodes_per_az = 1,
-      max_nodes_per_az = 2,
+      max_nodes_per_az = 4,
       node_instance    = "r6i.2xlarge"
       cache            = "cache.m6g.xlarge"
     },
     xlarge = {
       db               = "db.r6g.4xlarge",
       min_nodes_per_az = 1,
-      max_nodes_per_az = 2,
+      max_nodes_per_az = 4,
       node_instance    = "r6i.2xlarge"
       cache            = "cache.m6g.xlarge"
     },
     xxlarge = {
       db               = "db.r6g.8xlarge",
       min_nodes_per_az = 1,
-      max_nodes_per_az = 3,
+      max_nodes_per_az = 5,
       node_instance    = "r6i.4xlarge"
       cache            = "cache.m6g.2xlarge"
     }


### PR DESCRIPTION
The max k8s nodes setting is controlled in `deployment-size.tf` and is not defaulted in `core/../{aws,azure,google}/*.tf` nor `terraform-{aws,google,azurerm}-wandb/{main,variables}.tf`.

Recent platform incidents demonstrated that mass-pod replacement may fail for max node counts < 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Increased node capacity across various deployment sizes to enhance scalability and support higher loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->