### PR TITLE
fix: Bump max node sizes to ensure reliability as we increase HA deployments

### DIFF
--- a/deployment-size.tf
+++ b/deployment-size.tf
@@ -8,35 +8,35 @@ locals {
     small = {
       db               = "db.r6g.large",
       min_nodes_per_az = 1,
-      max_nodes_per_az = 2,
+      max_nodes_per_az = 4,
       node_instance    = "r6i.xlarge"
       cache            = "cache.m6g.large"
     },
     medium = {
       db               = "db.r6g.xlarge",
       min_nodes_per_az = 1,
-      max_nodes_per_az = 2,
+      max_nodes_per_az = 4,
       node_instance    = "r6i.xlarge"
       cache            = "cache.m6g.large"
     },
     large = {
       db               = "db.r6g.2xlarge",
       min_nodes_per_az = 1,
-      max_nodes_per_az = 2,
+      max_nodes_per_az = 4,
       node_instance    = "r6i.2xlarge"
       cache            = "cache.m6g.xlarge"
     },
     xlarge = {
       db               = "db.r6g.4xlarge",
       min_nodes_per_az = 1,
-      max_nodes_per_az = 2,
+      max_nodes_per_az = 4,
       node_instance    = "r6i.2xlarge"
       cache            = "cache.m6g.xlarge"
     },
     xxlarge = {
       db               = "db.r6g.8xlarge",
       min_nodes_per_az = 1,
-      max_nodes_per_az = 3,
+      max_nodes_per_az = 4,
       node_instance    = "r6i.4xlarge"
       cache            = "cache.m6g.2xlarge"
     }

--- a/variables.tf
+++ b/variables.tf
@@ -492,7 +492,7 @@ variable "bucket_kms_key_arn" {
 }
 variable "bucket_permissions_mode" {
   type        = string
-  description = "Defines the bucket permissiones mode, which can be one of: strict, restricted, or public."
+  description = "Defines the bucket permissions mode, which can be one of: strict, restricted, or public."
 
   validation {
     condition     = contains(["strict", "restricted", "public"], var.bucket_permissions_mode)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Increased the maximum number of nodes per availability zone for all deployment sizes, allowing for greater scalability.

- **Documentation**
  - Corrected a typographical error in the description of the bucket permissions mode variable for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->