### PR TITLE
fix: Bump operator chart and image versions to latest

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -29,13 +29,13 @@ variable "size" {
 variable "operator_chart_version" {
   type        = string
   description = "Version of the operator chart to deploy"
-  default     = "1.3.4"
+  default     = "1.4.2"
 }
 
 variable "controller_image_tag" {
   type        = string
   description = "Tag of the controller image to deploy"
-  default     = "1.14.0"
+  default     = "1.20.0"
 }
 
 variable "enable_helm_operator" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default operator chart version to 1.4.2.
  * Updated default controller image tag to 1.20.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->