### PR TITLE
fix: Increase instance sizes on all sizes up to large

### DIFF
--- a/deployment-size.tf
+++ b/deployment-size.tf
@@ -9,28 +9,28 @@ locals {
       db               = "db.r6g.large",
       min_nodes_per_az = 1,
       max_nodes_per_az = 4,
-      node_instance    = "r6i.xlarge"
+      node_instance    = "r6i.2xlarge"
       cache            = "cache.m6g.large"
     },
     medium = {
       db               = "db.r6g.xlarge",
       min_nodes_per_az = 1,
       max_nodes_per_az = 4,
-      node_instance    = "r6i.xlarge"
+      node_instance    = "r6i.4xlarge"
       cache            = "cache.m6g.large"
     },
     large = {
       db               = "db.r6g.2xlarge",
       min_nodes_per_az = 1,
       max_nodes_per_az = 4,
-      node_instance    = "r6i.2xlarge"
+      node_instance    = "r6i.4xlarge"
       cache            = "cache.m6g.xlarge"
     },
     xlarge = {
       db               = "db.r6g.4xlarge",
       min_nodes_per_az = 1,
       max_nodes_per_az = 4,
-      node_instance    = "r6i.2xlarge"
+      node_instance    = "r6i.4xlarge"
       cache            = "cache.m6g.xlarge"
     },
     xxlarge = {


### PR DESCRIPTION
Reshape default deployment sizes to better align with application needs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment size configurations to use larger instance types for small, medium, large, and xlarge options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->