### PR TITLE
fix: Output privatelink information

### DIFF
--- a/modules/private_link/outputs.tf
+++ b/modules/private_link/outputs.tf
@@ -1,0 +1,9 @@
+output "service_id" {
+  description = "The ID of the VPC Endpoint Service"
+  value       = aws_vpc_endpoint_service.private_link.id
+}
+
+output "availability_zones" {
+  description = "The Availability Zones where the NLB endpoints are available"
+  value       = aws_vpc_endpoint_service.private_link.availability_zones
+}

--- a/modules/private_link/outputs.tf
+++ b/modules/private_link/outputs.tf
@@ -1,3 +1,8 @@
+output "service_name" {
+  description = "The service name of the VPC Endpoint Service"
+  value       = aws_vpc_endpoint_service.private_link.service_name
+}
+
 output "service_id" {
   description = "The ID of the VPC Endpoint Service"
   value       = aws_vpc_endpoint_service.private_link.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -96,6 +96,11 @@ output "wandb_spec" {
 }
 
 # Private Link outputs - only available when private_link_allowed_account_ids is configured
+output "private_link_service_name" {
+  description = "The service name of the VPC Endpoint Service for Private Link"
+  value       = length(var.private_link_allowed_account_ids) > 0 ? module.private_link[0].service_name : null
+}
+
 output "private_link_service_id" {
   description = "The ID of the VPC Endpoint Service for Private Link"
   value       = length(var.private_link_allowed_account_ids) > 0 ? module.private_link[0].service_id : null

--- a/outputs.tf
+++ b/outputs.tf
@@ -94,3 +94,14 @@ output "wandb_spec" {
   value     = local.spec
   sensitive = true
 }
+
+# Private Link outputs - only available when private_link_allowed_account_ids is configured
+output "private_link_service_id" {
+  description = "The ID of the VPC Endpoint Service for Private Link"
+  value       = length(var.private_link_allowed_account_ids) > 0 ? module.private_link[0].service_id : null
+}
+
+output "private_link_availability_zones" {
+  description = "The Availability Zones where the Private Link NLB endpoints are available"
+  value       = length(var.private_link_allowed_account_ids) > 0 ? module.private_link[0].availability_zones : null
+}


### PR DESCRIPTION
Adds conditional outputs for VPC Endpoint Service information when `private_link_allowed_account_ids` is configured.
That makes the information easily available for SA share with the customers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added private link service name output.
  * Added private link service ID output.
  * Added private link availability zones output.
  * These outputs are conditionally populated only when private link is enabled (allowed accounts specified).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->